### PR TITLE
ci: Enable dependabot to update the pipelines submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+      schedule:
+        interval: "daily"
+    commit-message:
+      prefix: "build"
+    


### PR DESCRIPTION
## Changes

Enable dependabot to update the mobile-android-pipelines submodule (by enabling it to update any git submodule).

## Context

DCMAW-10478

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before publishing a pull request

- [x] Commit messages that conform to conventional commit messages.
- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete any relevant acceptance criteria
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
    * [ ] Unit Tests.
    * [ ] Integration Tests.
    * [ ] Instrumentation / Emulator Tests.

### Before merging a pull request
- [ ] Ensure the squash commit message follows conventional commit standards