### PR TITLE
ci: Split lint tasks into separate steps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,14 +29,14 @@ jobs:
         with:
           jdk-version: 21
 
-      - name: Lint project
-        run: |
-          ./gradlew \
-            detekt \
-            ktlintCheck \
-            vale
-        # TODO: migrate to the shared lint script
-        # run: ./mobile-android-pipelines/scripts/lintProject.sh "" ""
+      - name: Lint Kotlin with detekt
+        run: ./gradlew detekt
+
+      - name: Lint Kotlin with ktlint
+        run: ./gradlew ktlintCheck
+
+      - name: Lint documentation with vale
+        run: ./gradlew vale
 
       - name: Clean workspace
         if: ${{ always() }}


### PR DESCRIPTION
## Changes

- Remove TODO about using shared lint script. The script is meant to be used git hooks, not for CI. In Github Actions, it would be better to see each of the lint checks running in a separate step which can fail independently and output separate logs.
- Split the lint checks into separate Github Actions steps (see rationale above).

## Context

DCMAW-10478

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before publishing a pull request

- [ ] Commit messages that conform to conventional commit messages.
- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete any relevant acceptance criteria
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
    * [ ] Unit Tests.
    * [ ] Integration Tests.
    * [ ] Instrumentation / Emulator Tests.

### Before merging a pull request
- [ ] Ensure the squash commit message follows conventional commit standards