### PR TITLE
refactor: rename SDK module to align package names with Maven group ID

### DIFF
--- a/.github/workflows/upload-to-github-packages.yml
+++ b/.github/workflows/upload-to-github-packages.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   upload-to-github-packages:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+#    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       JDK_VERSION: 17
     permissions:

--- a/.github/workflows/upload-to-github-packages.yml
+++ b/.github/workflows/upload-to-github-packages.yml
@@ -5,16 +5,11 @@ on:
     workflows: [Bump version]
     branches: [main]
     types: [completed]
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
   workflow_dispatch:
 
 jobs:
   upload-to-github-packages:
-#    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       JDK_VERSION: 17
     permissions:

--- a/.github/workflows/upload-to-github-packages.yml
+++ b/.github/workflows/upload-to-github-packages.yml
@@ -5,6 +5,11 @@ on:
     workflows: [Bump version]
     branches: [main]
     types: [completed]
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
   workflow_dispatch:
 
 jobs:

--- a/modules/sdk/src/androidTest/java/uk/gov/onelogin/criorchestrator/sdk/ExampleInstrumentedTest.kt
+++ b/modules/sdk/src/androidTest/java/uk/gov/onelogin/criorchestrator/sdk/ExampleInstrumentedTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.criorchestrator.sdk
+package uk.gov.onelogin.criorchestrator.sdk
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals

--- a/modules/sdk/src/main/java/uk/gov/onelogin/criorchestrator/sdk/TestClass.kt
+++ b/modules/sdk/src/main/java/uk/gov/onelogin/criorchestrator/sdk/TestClass.kt
@@ -1,4 +1,4 @@
-package uk.gov.criorchestrator.sdk
+package uk.gov.onelogin.criorchestrator.sdk
 
 class TestClass {
     val greeting = "HELLO WORLD"

--- a/modules/sdk/src/test/java/uk/gov/onelogin/criorchestrator/sdk/ExampleUnitTest.kt
+++ b/modules/sdk/src/test/java/uk/gov/onelogin/criorchestrator/sdk/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.criorchestrator.sdk
+package uk.gov.onelogin.criorchestrator.sdk
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
- Correct package name for SDK module

## Evidence of the change
![image](https://github.com/user-attachments/assets/6005b4e4-25b9-4ea6-ad3a-a40a13d51e29)
Publishing to GitHub Packages now works

[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before publishing a pull request

- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [x] Complete any relevant acceptance criteria
- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- [x] Complete automated Testing:
    * [x] Unit Tests.
    * [ ] ~~Integration Tests.~~
    * [x] Instrumentation / Emulator Tests.
