### PR TITLE
build: Apply module namespaces automatically

### DIFF
--- a/modules/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/android-app-config.gradle.kts
+++ b/modules/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/android-app-config.gradle.kts
@@ -7,6 +7,7 @@ import uk.gov.onelogin.criorchestrator.extensions.setUiConfig
 import uk.gov.onelogin.criorchestrator.extensions.ideSupportDependencies
 import uk.gov.onelogin.criorchestrator.extensions.setBuildTypes
 import uk.gov.onelogin.criorchestrator.extensions.setJavaVersion
+import uk.gov.onelogin.criorchestrator.extensions.setNamespace
 import uk.gov.onelogin.criorchestrator.extensions.setPackagingConfig
 
 //https://github.com/gradle/gradle/issues/15383
@@ -34,6 +35,7 @@ listOf(
 configure<ApplicationExtension> {
     setUiConfig()
     setJavaVersion()
+    setNamespace(project = project)
     setBuildTypes()
     setPackagingConfig()
 }

--- a/modules/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/android-lib-config.gradle.kts
+++ b/modules/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/android-lib-config.gradle.kts
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import uk.gov.onelogin.criorchestrator.extensions.androidTestDependencies
 import uk.gov.onelogin.criorchestrator.extensions.setInstrumentationTestingConfig
 import uk.gov.onelogin.criorchestrator.extensions.setJavaVersion
+import uk.gov.onelogin.criorchestrator.extensions.setNamespace
 import uk.gov.onelogin.criorchestrator.extensions.testDependencies
 
 //https://github.com/gradle/gradle/issues/15383
@@ -22,6 +23,7 @@ listOf(
 configure<LibraryExtension> {
     setJavaVersion()
     setInstrumentationTestingConfig()
+    setNamespace(project = project)
 }
 
 configure<KotlinAndroidProjectExtension> {

--- a/modules/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/extensions/Android.kt
+++ b/modules/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/extensions/Android.kt
@@ -3,6 +3,7 @@ package uk.gov.onelogin.criorchestrator.extensions
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
+import org.gradle.api.Project
 
 private const val BASE_APPLICATION_ID = "uk.gov.onelogin.criorchestrator"
 private const val BASE_NAMESPACE = "uk.gov.onelogin.criorchestrator"
@@ -25,9 +26,10 @@ fun ApplicationExtension.setApplicationId(suffix: String) {
 /**
  * Set a namespace that starts with [BASE_NAMESPACE].
  */
-fun AndroidExtension.setNamespace(suffix: String) {
-    assert(suffix.isEmpty() || suffix.startsWith("."))
-    namespace = "$BASE_NAMESPACE$suffix"
+internal fun AndroidExtension.setNamespace(project: Project) {
+    val suffix = project.modulePathAsPackage()
+    val namespace = "$BASE_NAMESPACE.$suffix"
+    this.namespace = namespace
 }
 
 internal fun AndroidExtension.setJavaVersion() =

--- a/modules/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/extensions/Project.kt
+++ b/modules/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/extensions/Project.kt
@@ -1,0 +1,22 @@
+package uk.gov.onelogin.criorchestrator.extensions
+
+import org.gradle.api.Project
+
+/**
+ * Gets the module path in the style of a Java package.
+ *
+ * If the module path starts with `:modules`, this segment is not included in the result.
+ *
+ * For example, given a module with the module path `:modules:features:user:api` it returns
+ * `features.user.api`.
+ *
+ * @return The project's module path in the style of a Java package
+ */
+internal fun Project.modulePathAsPackage(): String =
+    project.path
+        .lowercase()
+        .removePrefix(":")
+        .removePrefix("modules:")
+        .replace("-", "")
+        .replace(":", ".")
+

--- a/modules/features/resume/internal-api/build.gradle.kts
+++ b/modules/features/resume/internal-api/build.gradle.kts
@@ -1,6 +1,3 @@
-import com.android.build.api.dsl.LibraryExtension
-import uk.gov.onelogin.criorchestrator.extensions.setNamespace
-
 plugins {
     listOf(
         "uk.gov.onelogin.criorchestrator.android-lib-config",
@@ -8,10 +5,6 @@ plugins {
     ).forEach {
         id(it)
     }
-}
-
-configure<LibraryExtension> {
-    setNamespace(suffix = ".features.resume.internalapi")
 }
 
 dependencies {

--- a/modules/features/resume/internal/build.gradle.kts
+++ b/modules/features/resume/internal/build.gradle.kts
@@ -1,6 +1,3 @@
-import com.android.build.api.dsl.LibraryExtension
-import uk.gov.onelogin.criorchestrator.extensions.setNamespace
-
 plugins {
     listOf(
         "uk.gov.onelogin.criorchestrator.android-lib-config",
@@ -8,10 +5,6 @@ plugins {
     ).forEach {
         id(it)
     }
-}
-
-configure<LibraryExtension> {
-    setNamespace(suffix = ".features.resume.internal")
 }
 
 dependencies {

--- a/modules/features/resume/public-api/build.gradle.kts
+++ b/modules/features/resume/public-api/build.gradle.kts
@@ -1,6 +1,3 @@
-import com.android.build.api.dsl.LibraryExtension
-import uk.gov.onelogin.criorchestrator.extensions.setNamespace
-
 plugins {
     listOf(
         "uk.gov.onelogin.criorchestrator.android-lib-config",
@@ -8,10 +5,6 @@ plugins {
     ).forEach {
         id(it)
     }
-}
-
-configure<LibraryExtension> {
-    setNamespace(suffix = ".features.resume.publicapi")
 }
 
 dependencies {

--- a/modules/sdk/internal/build.gradle.kts
+++ b/modules/sdk/internal/build.gradle.kts
@@ -1,16 +1,9 @@
-import com.android.build.api.dsl.LibraryExtension
-import uk.gov.onelogin.criorchestrator.extensions.setNamespace
-
 plugins {
     listOf(
         "uk.gov.onelogin.criorchestrator.android-lib-config",
     ).forEach {
         id(it)
     }
-}
-
-configure<LibraryExtension> {
-    setNamespace(suffix = ".sdk.internal")
 }
 
 dependencies {

--- a/modules/sdk/public-api/build.gradle.kts
+++ b/modules/sdk/public-api/build.gradle.kts
@@ -1,6 +1,3 @@
-import com.android.build.api.dsl.LibraryExtension
-import uk.gov.onelogin.criorchestrator.extensions.setNamespace
-
 plugins {
     listOf(
         "uk.gov.onelogin.criorchestrator.android-lib-config",
@@ -8,10 +5,6 @@ plugins {
     ).forEach {
         id(it)
     }
-}
-
-configure<LibraryExtension> {
-    setNamespace(suffix = ".sdk.publicapi")
 }
 
 dependencies {

--- a/modules/sdk/shared-api/build.gradle.kts
+++ b/modules/sdk/shared-api/build.gradle.kts
@@ -1,16 +1,9 @@
-import com.android.build.api.dsl.LibraryExtension
-import uk.gov.onelogin.criorchestrator.extensions.setNamespace
-
 plugins {
     listOf(
         "uk.gov.onelogin.criorchestrator.android-lib-config",
     ).forEach {
         id(it)
     }
-}
-
-configure<LibraryExtension> {
-    setNamespace(suffix = ".sdk.sharedapi")
 }
 
 dependencies {

--- a/modules/test-wrapper/build.gradle.kts
+++ b/modules/test-wrapper/build.gradle.kts
@@ -1,7 +1,6 @@
 import com.android.build.api.dsl.ApplicationExtension
 import uk.gov.onelogin.criorchestrator.extensions.configureEnvironmentFlavors
 import uk.gov.onelogin.criorchestrator.extensions.setApplicationId
-import uk.gov.onelogin.criorchestrator.extensions.setNamespace
 
 plugins {
     id("uk.gov.onelogin.criorchestrator.android-app-config")
@@ -9,7 +8,6 @@ plugins {
 
 configure<ApplicationExtension> {
     setApplicationId(suffix = ".testwrapper")
-    setNamespace(suffix = ".testwrapper")
     configureEnvironmentFlavors()
 }
 


### PR DESCRIPTION
## Changes

Apply module namespaces automatically based on the module path.

## Context

- Reduces boilerplate needed to set up new modules
- Reduces manual error in applying module namespaces

DCMAW-10843

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before publishing a pull request

- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete any relevant acceptance criteria
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
    * [ ] Unit Tests.
    * [ ] Integration Tests.
    * [ ] Instrumentation / Emulator Tests.
