### PR TITLE
fix: jdk version in pipeline

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -11,7 +11,7 @@ jobs:
   bump-version:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
-      JDK_VERSION: 17
+      JDK_VERSION: 21
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-to-github-packages.yml
+++ b/.github/workflows/upload-to-github-packages.yml
@@ -11,7 +11,7 @@ jobs:
   upload-to-github-packages:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
-      JDK_VERSION: 17
+      JDK_VERSION: 21
     permissions:
       packages: write
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-to-play-store.yml
+++ b/.github/workflows/upload-to-play-store.yml
@@ -11,7 +11,7 @@ jobs:
   upload-to-play-store:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
-      JDK_VERSION: 17
+      JDK_VERSION: 21
     runs-on: ubuntu-latest
     permissions:
       # Set permissions for ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- set jdk version in workflow to 21 (instead of 17)

# Evidence
- previous workflows (lint and test) were also failing because of java incompatibility issues, and these changes fixed them