### PR TITLE
fix: upload to play store and packages workflows

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Setup GitHub Runner workflow
         uses: ./mobile-android-pipelines/actions/setup-runner
+        with:
+          jdk-version: 21
 
       - name: Increment the release version using Conventional Commits
         id: versioning

--- a/.github/workflows/upload-to-github-packages.yml
+++ b/.github/workflows/upload-to-github-packages.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Setup GitHub Runner workflow
         uses: ./mobile-android-pipelines/actions/setup-runner
+        with:
+          jdk-version: 21
 
       - name: Publish package
         uses: ./mobile-android-pipelines/actions/maven-publish

--- a/.github/workflows/upload-to-play-store.yml
+++ b/.github/workflows/upload-to-play-store.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Setup GitHub Runner workflow
         uses: ./mobile-android-pipelines/actions/setup-runner
+        with:
+          jdk-version: 21
 
       - name: Retrieve GitHub secrets
         id: retrieve-secrets


### PR DESCRIPTION
- add `with: jdk-version: 21` option to setup runner steps