### PR TITLE
fix: remove AD_ID permissions declared by Firebase

### DIFF
--- a/test-wrapper/src/main/AndroidManifest.xml
+++ b/test-wrapper/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Firebase automatically adds the AD_ID permission, we don't need this. -->
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
+
     <application
         android:allowBackup="false"
         android:fullBackupContent="false"
@@ -28,6 +33,10 @@
         <meta-data
             android:name="firebase_crashlytics_collection_enabled"
             android:value="true" />
+        <!-- Disable AD_ID usage in Google Analytics data collection -->
+        <meta-data
+            android:name="google_analytics_adid_collection_enabled"
+            android:value="false" />
         <!-- Disable screen view tracking
         https://firebase.google.com/docs/analytics/screenviews#disable_screenview_tracking -->
         <meta-data


### PR DESCRIPTION
Fix failing deployment caused by AD_ID usage:
https://github.com/govuk-one-login/mobile-android-cri-orchestrator/actions/runs/13007039929/job/36276116364