### PR TITLE
ci: Assemble project for Sonar analysis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Sonar analyzers must have access to the bytecode to perform an accurate analysis.
+  # https://community.sonarsource.com/t/sonarscanner-for-gradle-you-can-now-decide-when-to-compile/102069
+  assemble:
+    name: Assemble
+    runs-on: ubuntu-latest
+    permissions:
+      # Set permissions for ${{ secrets.GITHUB_TOKEN }}
+      # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+      packages: read
+    steps:
+      - name: Run checkout github action
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          lfs: 'true'
+          submodules: 'true'
+          fetch-depth: 0
+
+      - name: Set up git runner
+        uses: ./mobile-android-pipelines/actions/setup-runner
+        with:
+          jdk-version: 21
+
+      - name: Assemble
+        run: ./gradlew assemble
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload jars
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: jars
+          path: "**/build/**/*.jar"
+
+      - name: Clean workspace
+        if: ${{ always() }}
+        uses: ./mobile-android-pipelines/actions/clean-workspace
+
   unit-test:
     name: Unit test
     runs-on: ubuntu-latest
@@ -91,6 +129,7 @@ jobs:
     name: Scan with Sonar
     runs-on: ubuntu-latest
     needs:
+      - assemble
       - unit-test
       - instrumentation-test
     steps:
@@ -106,13 +145,10 @@ jobs:
         with:
           jdk-version: 21
 
-      # Sonar seems to need pure Kotlin/Java modules to have their .jar files pre-built before
-      # running the sonar task.
-      - name: Assemble pure Kotlin/Java modules
-        run: ./gradlew :libraries:di:assemble
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download jars
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: jars
 
       - name: Download unit test coverage reports
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8


### PR DESCRIPTION
## Change

Assemble project prior to scanning with Sonar.

## Context

Enables adding test fixtures to the project in https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/82.

> Sonar analyzers must have access to the bytecode to perform an accurate analysis

– https://community.sonarsource.com/t/sonarscanner-for-gradle-you-can-now-decide-when-to-compile/102069


DCMAW-11241

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before publishing a pull request

- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete any relevant acceptance criteria
- [x] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
    * [ ] Unit Tests.
    * [ ] Integration Tests.
    * [ ] Instrumentation / Emulator Tests.
