### PR TITLE
ci: Remove redundant job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,44 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Sonar analyzers must have access to the bytecode to perform an accurate analysis.
-  # https://community.sonarsource.com/t/sonarscanner-for-gradle-you-can-now-decide-when-to-compile/102069
-  assemble:
-    name: Assemble
-    runs-on: ubuntu-latest
-    permissions:
-      # Set permissions for ${{ secrets.GITHUB_TOKEN }}
-      # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-      packages: read
-    steps:
-      - name: Run checkout github action
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          lfs: 'true'
-          submodules: 'true'
-          fetch-depth: 0
-
-      - name: Set up git runner
-        uses: ./mobile-android-pipelines/actions/setup-runner
-        with:
-          jdk-version: 21
-
-      - name: Assemble
-        run: ./gradlew assemble
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload jars
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        with:
-          name: jars
-          path: "**/build/**/*.jar"
-
-      - name: Clean workspace
-        if: ${{ always() }}
-        uses: ./mobile-android-pipelines/actions/clean-workspace
-
   unit-test:
     name: Unit test
     runs-on: ubuntu-latest
@@ -80,6 +42,14 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Sonar analyzers must have access to the bytecode to perform an accurate analysis.
+      # https://community.sonarsource.com/t/sonarscanner-for-gradle-you-can-now-decide-when-to-compile/102069
+      - name: Upload jars
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: jars
+          path: "**/build/**/*.jar"
 
       - name: Upload test coverage report
         uses: ./mobile-android-pipelines/actions/upload-coverage-reports
@@ -129,7 +99,6 @@ jobs:
     name: Scan with Sonar
     runs-on: ubuntu-latest
     needs:
-      - assemble
       - unit-test
       - instrumentation-test
     steps:


### PR DESCRIPTION
## Changes

- Remove the redundant assemble step added in #95
- Upload jars needed for Sonar scanning after running unit tests

## Context

The jars needed for Sonar scanning are already calculated in the unit test job so use them instead. Also, Sonar only seems to need the jars compiled for the debug build type.

This change will also enable Sonar analysis after enabling test fixtures to the project (introduced in #82).

- Improvement on #95 

DCMAW-8694

[Tutorial for writing good descriptions]: https://cbea.ms/git-commit/

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before publishing a pull request

- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete any relevant acceptance criteria
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
    * [ ] Unit Tests.
    * [ ] Integration Tests.
    * [ ] Instrumentation / Emulator Tests.
