### PR TITLE
ci: Group kotlin and ksp updates using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,7 @@ updates:
       kotlin:
         patterns:
           - "org.jetbrains.kotlin*"
-          - "com.google.devtools.ksp"
+          - "com.google.devtools.ksp*"
       gradle:
         update-types:
           - "minor"


### PR DESCRIPTION
## Changes

Add Dependabot grouping rule to ensure Kotlin and ksp are updated together.

## Context

Dependabot raised an update for Kotlin (#89) without updating ksp, however the two should be updated together for compatibility.

This PR doesn't prevent Kotlin and ksp getting updated indepenently but it does prevent Kotlin or ksp updates slipping through in the catch-all group.

## Checklist

### Before publishing a pull request

- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete any relevant acceptance criteria
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
    * [ ] Unit Tests.
    * [ ] Integration Tests.
    * [ ] Instrumentation / Emulator Tests.
