### PR TITLE
test: Restrict screenshots to previews from current module

### DIFF
--- a/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/ScreenshotTest.kt
+++ b/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/ScreenshotTest.kt
@@ -5,13 +5,15 @@ import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import org.junit.runner.RunWith
 import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
 import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
-import uk.gov.onelogin.criorchestrator.libraries.screenshottesting.AllPreviewsProvider
 import uk.gov.onelogin.criorchestrator.libraries.screenshottesting.BaseScreenshotTest
+import uk.gov.onelogin.criorchestrator.libraries.screenshottesting.PackagePreviewsProvider
+
+private object ModulePackagePreviewsProvider : PackagePreviewsProvider()
 
 @RunWith(TestParameterInjector::class)
 class ScreenshotTest(
     @TestParameter(
-        valuesProvider = AllPreviewsProvider::class,
+        valuesProvider = ModulePackagePreviewsProvider::class,
     )
     preview: ComposablePreview<AndroidPreviewInfo>,
 ) : BaseScreenshotTest(preview = preview)

--- a/libraries/screenshot-testing/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/libraries/screenshottesting/BaseScreenshotTest.kt
+++ b/libraries/screenshot-testing/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/libraries/screenshottesting/BaseScreenshotTest.kt
@@ -13,16 +13,18 @@ import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
 /**
  * A base class to execute screenshot tests.
  *
- * Extend this class and use together with [AllPreviewsProvider] to generate screenshot tests for
+ * Extend this class and use together with [PackagePreviewsProvider] to generate screenshot tests for
  * all the Composable previews in the project.
  *
  * #### Example usage
  *
  * ```kt
+ * private object ModulePackagePreviewsProvider: PackagePreviewsProvider()
+ *
  * @RunWith(TestParameterInjector::class)
  * class ScreenshotTest(
  *     @TestParameter(
- *         valuesProvider = AllPreviewsProvider::class,
+ *         valuesProvider = ModulePackagePreviewsProvider::class,
  *     )
  *     preview: ComposablePreview<AndroidPreviewInfo>,
  * ) : BaseScreenshotTest(preview = preview)

--- a/libraries/screenshot-testing/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/libraries/screenshottesting/PackagePreviewsProvider.kt
+++ b/libraries/screenshot-testing/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/libraries/screenshottesting/PackagePreviewsProvider.kt
@@ -5,14 +5,21 @@ import sergio.sastre.composable.preview.scanner.android.AndroidComposablePreview
 import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
 import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
 
-private const val BASE_PACKAGE = "uk.gov.onelogin.criorchestrator"
-
 /**
- * A [TestParameterValuesProvider] that provides all the composable previews found in the project.
+ * A [TestParameterValuesProvider] that provides all the composable previews found with the same
+ * package as the instance of this class.
+ *
+ * To create a provider for a given module, create a new subclass in the module.
+ *
+ * ```kt
+ * object ModulePackagePreviewsProvider: PackagePreviewsProvider()
+ * ```
  */
-class AllPreviewsProvider : TestParameterValuesProvider() {
+abstract class PackagePreviewsProvider : TestParameterValuesProvider() {
+    private val namespace = this::class.java.`package`!!.name
+
     override fun provideValues(context: Context?): List<ComposablePreview<AndroidPreviewInfo>> =
         AndroidComposablePreviewScanner()
-            .scanPackageTrees(BASE_PACKAGE)
+            .scanPackageTrees(namespace)
             .getPreviews()
 }


### PR DESCRIPTION
## Problem

Screenshots are generated by searching the project for composable previews and generating tests based on what's found.

However, tests in different modules scan for previews in every module, resulting in a lot of duplicate screenshots.

## Solution

Restrict screenshot tests to previews found in the same module as the test.

DCMAW-11241

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before publishing a pull request

- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete any relevant acceptance criteria
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
    * [ ] Unit Tests.
    * [ ] Integration Tests.
    * [ ] Instrumentation / Emulator Tests.
