### PR TITLE
fix: Remove activity dependency that forces compile SDK 35

### DIFF
--- a/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/extensions/Dependencies.kt
+++ b/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/extensions/Dependencies.kt
@@ -51,7 +51,6 @@ internal fun DependencyHandlerScope.uiDependencies(libs: LibrariesForLibs) = lis
     libs.androidx.appcompat,
     libs.material,
     libs.androidx.lifecycle.runtime.ktx,
-    libs.androidx.activity.compose,
     libs.androidx.ui.graphics,
     libs.androidx.ui.tooling.preview,
     libs.androidx.material3,

--- a/test-wrapper/build.gradle.kts
+++ b/test-wrapper/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
         libs.uk.gov.logging.api,
         libs.uk.gov.logging.impl,
         libs.uk.gov.networking,
+        libs.androidx.activity.compose,
         project(":sdk:public-api"),
         project(":sdk:shared-api"),
         platform(libs.firebase.bom),


### PR DESCRIPTION
## Problem

- Including `androidx.activity:activity-compose:1.10.0` as a transitive dependency forces consuming applications to be compiled with Android SDK version 35.
- Including `androidx.activity:activity-compose` in any module that displays UI is redundant as there are no Activities in the production codebase.

## Solution

Remove the dependency on `androidx.activity:activity-compose` from every module except the test wrapper app.

DCMAW-10695

## Evidence of the change

Tested manually by setting the compile SDK version of the test wrapper app to 34 and it compiles.

## Checklist

### Before publishing a pull request

- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete any relevant acceptance criteria
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
    * [ ] Unit Tests.
    * [ ] Integration Tests.
    * [ ] Instrumentation / Emulator Tests.
