### PR TITLE
ci: Cache `mobile-android-pipelines` build

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           jdk-version: 21
 
+      - name: Cache mobile-android-pipelines build
+        uses: ./actions/cache-pipelines-build
+
       - name: Lint
         uses: govuk-one-login/mobile-android-pipelines/actions/lint@be6882791c9d7f538c9d32d9db281dd5299da653
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           jdk-version: 21
 
+      - name: Cache mobile-android-pipelines build
+        uses: ./actions/cache-pipelines-build
+
       - name: Unit test
         # Exclude Konsist unit tests which are actually lint checks
         # Build all unit tests so that jars are available for Sonar
@@ -90,6 +93,9 @@ jobs:
         with:
           jdk-version: 21
 
+      - name: Cache mobile-android-pipelines build
+        uses: ./actions/cache-pipelines-build
+
       - name: Instrumentation test
         run: ./gradlew allDevicesCheck
         env:
@@ -123,6 +129,9 @@ jobs:
         uses: ./mobile-android-pipelines/actions/setup-runner
         with:
           jdk-version: 21
+
+      - name: Cache mobile-android-pipelines build
+        uses: ./actions/cache-pipelines-build
 
       - name: Download jars
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8

--- a/.github/workflows/upload-to-github-packages.yml
+++ b/.github/workflows/upload-to-github-packages.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           jdk-version: 21
 
+      - name: Cache mobile-android-pipelines build
+        uses: ./actions/cache-pipelines-build
+
       - name: Publish package
         uses: ./mobile-android-pipelines/actions/maven-publish
         with:

--- a/.github/workflows/upload-to-play-store.yml
+++ b/.github/workflows/upload-to-play-store.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           jdk-version: 21
 
+      - name: Cache mobile-android-pipelines build
+        uses: ./actions/cache-pipelines-build
+
       - name: Retrieve GitHub secrets
         id: retrieve-secrets
         uses: ./mobile-android-pipelines/actions/retrieve-secrets

--- a/actions/cache-pipelines-build/action.yml
+++ b/actions/cache-pipelines-build/action.yml
@@ -1,0 +1,17 @@
+name: Cache mobile-android-pipelines build
+description: Caches the build for Gradle plugins and build logic
+
+runs:
+  using: "composite"
+  steps:
+  - name: Get mobile-android-pipelines commit
+    run: echo "PIPELINES_COMMIT=$(git rev-parse HEAD:mobile-android-pipelines)" >> $GITHUB_ENV
+    shell: bash
+
+  - name: Cache mobile-android-pipelines build
+    uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+    with:
+      key: mobile-android-pipelines-build-${{ env.PIPELINES_COMMIT }}
+      path: |
+        mobile-android-pipelines/buildLogic/**/build/**/*
+        mobile-android-pipelines/buildLogic/.gradle/**/*


### PR DESCRIPTION
## Changes

Cache `mobile-android-pipelines` plugins build.

## Context

This will speed up the build of every Github CI/CD workflow that needs to build the project.

## Evidence of the change

The change needs to be merged to `main` before cache entries are written.

In the actions run on this PR, you can see the cache miss and associated cache key:

```
Cache not found for input keys: mobile-android-pipelines-build-6eb38183ca56030f33817f9c49f8ede5a2219fbe
```

### Result after merging to main

<img width="1001" alt="Screenshot 2025-02-03 at 11 11 21" src="https://github.com/user-attachments/assets/68e94343-9b13-423c-b671-4b8ea0d142ba" />


## Checklist

### Before publishing a pull request

- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete any relevant acceptance criteria
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
    * [ ] Unit Tests.
    * [ ] Integration Tests.
    * [ ] Instrumentation / Emulator Tests.
