### PR TITLE
ci: Don't run placeholder instrumenation tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
         uses: ./actions/cache-pipelines-build
 
       - name: Instrumentation test
-        run: ./gradlew allDevicesCheck
+        run: ./gradlew :test-wrapper:allDevicesBuildDebugAndroidTest
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

Stop wasting time running slow placeholder instrumentation tests.

## Context

Due to a bug in `mobile-android-pipelines` Jacoco and Sonar plugins it isn't possible to create an Android library without an associated instrumentation test (ticket TBC). Hence we have a lot of tests that add no value.

Until we can delete these tests, this PR updates the workflow so that they aren't run at all.

## Evidence of the change

| Example workflow | Time taken |
|------------------|------------|
| [Before]         | 7m 56s     |
| [After]          | 2m 47s     |

[Before]: https://github.com/govuk-one-login/mobile-android-cri-orchestrator/actions/runs/13120808184/job/36606043310
[After]: https://github.com/govuk-one-login/mobile-android-cri-orchestrator/actions/runs/13118970703/job/36600159832


[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before publishing a pull request

- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete any relevant acceptance criteria
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
    * [ ] Unit Tests.
    * [ ] Integration Tests.
    * [ ] Instrumentation / Emulator Tests.
