### PR TITLE
test: Fix konsist dependency setup

### DIFF
--- a/konsist-test/build.gradle.kts
+++ b/konsist-test/build.gradle.kts
@@ -25,5 +25,6 @@ tasks.withType<Test> {
 }
 
 dependencies {
-    testFixturesApi(libs.com.lemonappdev.konsist)
+    testImplementation(libs.com.lemonappdev.konsist)
+    testFixturesCompileOnly(libs.com.lemonappdev.konsist)
 }


### PR DESCRIPTION
## Problem

When running the Android test build,

```
./gradlew assembleDebugAndroidTest
```

the task fails with an error:

```
Execution failed for task ':konsist-test:mergeDebugAndroidTestJavaResource'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeJavaResWorkAction
   > 2 files found with path 'kotlin/internal/internal.kotlin_builtins' from inputs:
      - org.jetbrains.kotlin:kotlin-compiler-embeddable:2.0.21/kotlin-compiler-embeddable-2.0.21.jar
      - org.jetbrains.kotlin:kotlin-stdlib:2.1.10/kotlin-stdlib-2.1.10.jar
     Adding a packaging block may help, please refer to
     https://developer.android.com/reference/tools/gradle-api/com/android/build/api/dsl/Packaging
     for more information
```

## Solution

The issue is caused by the use of `testFixtures` which is shared between `test` and `androidTest`.

This PR changes the configuration so that `konsist` is not available in `androidTest`.

DCMAW-11362

## Evidence of the change

To test manually, run 

```
./gradlew assembleDebugAndroidTest
```

Note the output

```
BUILD SUCCESSFUL
```


[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before publishing a pull request

- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete any relevant acceptance criteria
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
    * [ ] Unit Tests.
    * [ ] Integration Tests.
    * [ ] Instrumentation / Emulator Tests.
