### PR TITLE
ci: Improve test job run time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,8 @@ jobs:
           submodules: 'true'
           fetch-depth: 0
 
-      - name: Set up git runner
-        uses: ./mobile-android-pipelines/actions/setup-runner
-        with:
-          jdk-version: 21
+      - name: Set up GitHub runner
+        uses: ./actions/setup-runner
 
       - name: Cache mobile-android-pipelines build
         uses: ./actions/cache-pipelines-build
@@ -88,10 +86,8 @@ jobs:
           submodules: 'true'
           fetch-depth: 0
 
-      - name: Set up git runner
-        uses: ./mobile-android-pipelines/actions/setup-runner
-        with:
-          jdk-version: 21
+      - name: Set up GitHub runner
+        uses: ./actions/setup-runner
 
       - name: Cache mobile-android-pipelines build
         uses: ./actions/cache-pipelines-build
@@ -126,10 +122,8 @@ jobs:
           submodules: 'true'
           fetch-depth: 0
 
-      - name: Setup runner
-        uses: ./mobile-android-pipelines/actions/setup-runner
-        with:
-          jdk-version: 21
+      - name: Set up GitHub runner
+        uses: ./actions/setup-runner
 
       - name: Cache mobile-android-pipelines build
         uses: ./actions/cache-pipelines-build

--- a/actions/setup-runner/action.yml
+++ b/actions/setup-runner/action.yml
@@ -1,0 +1,17 @@
+name: 'Setup runner'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Java
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
+
+    - name: Install cocogitto
+      uses: cocogitto/cocogitto-action@ed62593c499c2d7697bb0177213946f1e2634119 # v3.10
+      with:
+        check: false


### PR DESCRIPTION
## Changes

Install Java, Gradle and Cocogitto using a local Github Action, rather than the one in `mobile-android-pipelines`, which is bloated with unused dependencies (issue TBC).

## Context

DCMAW-11362

## Evidence of the change

| `setup-runner` step | Time taken |
|---------------------|------------|
| [Before]            | 2m 8s      |
| [After]             | 29s        |

[Before]: https://github.com/govuk-one-login/mobile-android-cri-orchestrator/actions/runs/13137528123/job/36656393787
[After]: https://github.com/govuk-one-login/mobile-android-cri-orchestrator/actions/runs/13137888981/job/36657560190

## Checklist

### Before publishing a pull request

- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete any relevant acceptance criteria
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
    * [ ] Unit Tests.
    * [ ] Integration Tests.
    * [ ] Instrumentation / Emulator Tests.
