### PR TITLE
ci: Set up Dependabot to access GitHub packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ registries:
   github-maven:
     type: maven-repository
     url: https://maven.pkg.github.com
-    username: ${{ secrets.DEPENDABOT_GITHUB_USERNAME }}
-    password: ${{ secrets.DEPENDABOT_GITHUB_TOKEN }}
+    username: ${{ secrets.MODULE_FETCH_TOKEN_USERNAME }}
+    password: ${{ secrets.MODULE_FETCH_TOKEN }}
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Changes

Set up Dependabot to access GitHub Packages.

- [x] Add [Dependabot secrets](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot#adding-a-repository-secret-for-dependabot)

## Context

Currently, some internal Github packages are not publicly accessible so Dependabot can't check for updates.

DCMAW-10552

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before publishing a pull request

- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete any relevant acceptance criteria
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
    * [ ] Unit Tests.
    * [ ] Integration Tests.
    * [ ] Instrumentation / Emulator Tests.
