### PR TITLE
ci: Fix environment for publishing step

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Publish to Github Packages
         if: ${{ github.event_name != 'pull_request' }}
         uses: ./mobile-android-pipelines/actions/maven-publish
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
 
       - name: Test publishing to Maven local
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Changes

- Revert change to inputs/environment variables needed for publishing

## Context

- Failed run: https://github.com/govuk-one-login/mobile-android-cri-orchestrator/actions/runs/13268928779/job/37043420741
- Caused by https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/138

DCMAW-11481

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
