### PR TITLE
ci: Fix data sharing between workflows

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -38,6 +38,7 @@ jobs:
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         with:
           name: bump-version-outputs
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Enable publishing if triggered manually
         if: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Problem

The `publish-packages.yml` workflow cannot access outputs from the `bump-version.yml` workflow because it doesn't specify which workflow run ID from which to download the artifacts.

- Failed workflow run: https://github.com/govuk-one-login/mobile-android-cri-orchestrator/actions/runs/13308636134 

```
Run actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
Downloading single artifact
Error: Unable to download artifact(s): Artifact not found for name: bump-version-outputs
        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.
```

## Solution

As per the [documentation], add the `run-id` parameter to the `download-artifact` action.

[documentation]: https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [x] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
