### PR TITLE
ci: Fix data sharing between workflows

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           name: bump-version-outputs
           run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable publishing if triggered manually
         if: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Change

Use Github token to to download shared workflow outputs.

## Context

> The GitHub token used to authenticate with the GitHub API.
> This is required when downloading artifacts from a different repository **or from a different workflow run**.

– https://github.com/actions/download-artifact?tab=readme-ov-file#inputs

DCMAW-11481

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
