### PR TITLE
fix: Bump logging version to exclude Hilt Modules

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ paparazzi = "1.3.5"
 robolectric = "4.14.1"
 testparameterinjector = "1.18"
 turbine = "1.2.0"
-uk-gov-logging = "0.12.0" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
+uk-gov-logging = "0.15.0" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.3.4"
 uk-gov-ui = "7.0.0"
 


### PR DESCRIPTION
# DCMAW-10694
**This is a interim PR to allow testing it in the one-login app**

- update `logging` version to `0.15.0` (it should be a major bump but it did not trigger it - seems the first major bump needs to be manual) - this version contains only the apis and imp for those to be used/ injected from the consumers, solving dependency issues resulted when attempting to integrate into `one-login-app`

- in previous versions of the `logging` module, there existed Hilt modules that injected implementations into consuming codebases. This has been causing conflicting/duplicate binding issues during the integration of the CRI Orchestrator into the One Login app. To address this, the Hilt modules in the `logging` repo have been removed, and this PR consumes the new packages.
- Since the CRI Orchestrator doesn't use the Hilt modules, no further changes need to be made in this PR.

- This has been tested via integration with the One Login app and works.
## Checklist

- [x] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
