### PR TITLE
refactor: Extract 'resume' analytics into separate class

### DIFF
--- a/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/analytics/ResumeAnalytics.kt
+++ b/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/analytics/ResumeAnalytics.kt
@@ -1,0 +1,33 @@
+package uk.gov.onelogin.criorchestrator.features.resume.internal.analytics
+
+import androidx.annotation.StringRes
+import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel2
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel3
+import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
+import uk.gov.logging.api.v3dot1.model.RequiredParameters
+import uk.gov.logging.api.v3dot1.model.TrackEvent
+import uk.gov.onelogin.criorchestrator.libraries.androidutils.resources.ResourceProvider
+import javax.inject.Inject
+
+class ResumeAnalytics
+    @Inject
+    constructor(
+        private val resourceProvider: ResourceProvider,
+        private val analyticsLogger: AnalyticsLogger,
+    ) {
+        private val requiredParameters =
+            RequiredParameters(
+                taxonomyLevel2 = TaxonomyLevel2.DOCUMENT_CHECKING_APP,
+                taxonomyLevel3 = TaxonomyLevel3.RESUME,
+            )
+
+        fun trackButtonEvent(
+            @StringRes buttonText: Int,
+        ) = analyticsLogger.logEventV3Dot1(
+            TrackEvent.Button(
+                text = resourceProvider.getEnglishString(buttonText),
+                params = requiredParameters,
+            ),
+        )
+    }

--- a/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityViewModel.kt
+++ b/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityViewModel.kt
@@ -7,20 +7,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import uk.gov.logging.api.LogTagProvider
 import uk.gov.logging.api.Logger
-import uk.gov.logging.api.analytics.logging.AnalyticsLogger
-import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel2
-import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel3
-import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
-import uk.gov.logging.api.v3dot1.model.RequiredParameters
-import uk.gov.logging.api.v3dot1.model.TrackEvent
 import uk.gov.onelogin.criorchestrator.features.resume.internal.R
+import uk.gov.onelogin.criorchestrator.features.resume.internal.analytics.ResumeAnalytics
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionReader
-import uk.gov.onelogin.criorchestrator.libraries.androidutils.resources.ResourceProvider
 
 internal class ProveYourIdentityViewModel(
     private val sessionReader: SessionReader,
-    private val analyticsLogger: AnalyticsLogger,
-    private val resourceProvider: ResourceProvider,
+    private val analytics: ResumeAnalytics,
     private val logger: Logger,
 ) : ViewModel(),
     LogTagProvider {
@@ -37,16 +30,9 @@ internal class ProveYourIdentityViewModel(
     }
 
     fun start() {
-        val proveIdentityEvent =
-            TrackEvent.Button(
-                text = resourceProvider.getEnglishString(R.string.start_id_check_primary_button),
-                params =
-                    RequiredParameters(
-                        taxonomyLevel2 = TaxonomyLevel2.DOCUMENT_CHECKING_APP,
-                        taxonomyLevel3 = TaxonomyLevel3.RESUME,
-                    ),
-            )
-        analyticsLogger.logEventV3Dot1(proveIdentityEvent)
+        analytics.trackButtonEvent(
+            buttonText = R.string.start_id_check_primary_button,
+        )
     }
 
     private fun checkActiveSession() {

--- a/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityViewModelModule.kt
+++ b/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityViewModelModule.kt
@@ -7,9 +7,8 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import uk.gov.logging.api.Logger
-import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.onelogin.criorchestrator.features.resume.internal.analytics.ResumeAnalytics
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionReader
-import uk.gov.onelogin.criorchestrator.libraries.androidutils.resources.ResourceProvider
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 import javax.inject.Named
 
@@ -21,16 +20,14 @@ object ProveYourIdentityViewModelModule {
     @Provides
     @Named(FACTORY_NAME)
     fun provideFactory(
-        analyticsLogger: AnalyticsLogger,
-        resourceProvider: ResourceProvider,
+        resumeAnalytics: ResumeAnalytics,
         sessionReader: SessionReader,
         logger: Logger,
     ): ViewModelProvider.Factory =
         viewModelFactory {
             initializer {
                 ProveYourIdentityViewModel(
-                    analyticsLogger = analyticsLogger,
-                    resourceProvider = resourceProvider,
+                    analytics = resumeAnalytics,
                     sessionReader = sessionReader,
                     logger = logger,
                 )

--- a/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/ProveYourIdentityEntryPointsImplTest.kt
+++ b/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/ProveYourIdentityEntryPointsImplTest.kt
@@ -11,13 +11,13 @@ import kotlinx.collections.immutable.persistentSetOf
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.logging.testdouble.SystemLogger
-import uk.gov.logging.testdouble.analytics.FakeAnalyticsLogger
+import uk.gov.onelogin.criorchestrator.features.resume.internal.analytics.ResumeAnalytics
 import uk.gov.onelogin.criorchestrator.features.resume.internal.root.ProveYourIdentityViewModel
 import uk.gov.onelogin.criorchestrator.features.resume.internal.screen.ContinueToProveYourIdentityNavGraphProvider
 import uk.gov.onelogin.criorchestrator.features.session.internal.StubSessionReader
-import uk.gov.onelogin.criorchestrator.libraries.androidutils.resources.FakeResourceProvider
 
 @RunWith(AndroidJUnit4::class)
 class ProveYourIdentityEntryPointsImplTest {
@@ -26,8 +26,7 @@ class ProveYourIdentityEntryPointsImplTest {
 
     private val fakeProveYourIdentityViewModel =
         ProveYourIdentityViewModel(
-            analyticsLogger = FakeAnalyticsLogger(),
-            resourceProvider = FakeResourceProvider(),
+            analytics = mock<ResumeAnalytics>(),
             sessionReader = StubSessionReader(),
             logger = SystemLogger(),
         )

--- a/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/analytics/ResumeAnalyticsTest.kt
+++ b/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/analytics/ResumeAnalyticsTest.kt
@@ -1,0 +1,64 @@
+package uk.gov.onelogin.criorchestrator.features.resume.internal.analytics
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
+import org.robolectric.annotation.Config
+import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel2
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel3
+import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
+import uk.gov.logging.api.v3dot1.model.RequiredParameters
+import uk.gov.logging.api.v3dot1.model.TrackEvent
+import uk.gov.onelogin.criorchestrator.features.resume.internal.R
+import uk.gov.onelogin.criorchestrator.libraries.androidutils.resources.AndroidResourceProvider
+
+@RunWith(AndroidJUnit4::class)
+class ResumeAnalyticsTest {
+    val analyticsLogger = mock<AnalyticsLogger>()
+    val context: Context = ApplicationProvider.getApplicationContext()
+
+    val analytics by lazy {
+        ResumeAnalytics(
+            resourceProvider = AndroidResourceProvider(context = context),
+            analyticsLogger = analyticsLogger,
+        )
+    }
+
+    companion object {
+        @StringRes
+        val buttonText = R.string.start_id_check_primary_button
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    fun `given english locale, track button tracks correctly`() {
+        analytics.trackButtonEvent(buttonText = buttonText)
+        verifyTrackButtonEvent()
+    }
+
+    @Test
+    @Config(qualifiers = "cy")
+    fun `given welsh locale, track button tracks correctly`() {
+        analytics.trackButtonEvent(buttonText = buttonText)
+        verifyTrackButtonEvent()
+    }
+
+    private fun verifyTrackButtonEvent() {
+        verify(analyticsLogger).logEventV3Dot1(
+            TrackEvent.Button(
+                text = "Continue proving your identity",
+                params =
+                    RequiredParameters(
+                        taxonomyLevel2 = TaxonomyLevel2.DOCUMENT_CHECKING_APP,
+                        taxonomyLevel3 = TaxonomyLevel3.RESUME,
+                    ),
+            ),
+        )
+    }
+}

--- a/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityRootTest.kt
+++ b/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityRootTest.kt
@@ -17,14 +17,14 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.kotlin.verify
 import uk.gov.logging.testdouble.SystemLogger
-import uk.gov.logging.testdouble.analytics.FakeAnalyticsLogger
 import uk.gov.onelogin.criorchestrator.features.resume.internal.R
+import uk.gov.onelogin.criorchestrator.features.resume.internal.analytics.ResumeAnalytics
 import uk.gov.onelogin.criorchestrator.features.resume.internal.screen.ContinueToProveYourIdentityNavGraphProvider
 import uk.gov.onelogin.criorchestrator.features.session.internal.StubSessionReader
-import uk.gov.onelogin.criorchestrator.libraries.androidutils.resources.AndroidResourceProvider
 
 @RunWith(AndroidJUnit4::class)
 class ProveYourIdentityRootTest {
@@ -32,12 +32,10 @@ class ProveYourIdentityRootTest {
     val composeTestRule = createComposeRule()
 
     private val context: Context = ApplicationProvider.getApplicationContext()
-    private val resourceProvider = AndroidResourceProvider(context)
     private val viewModel =
         spy(
             ProveYourIdentityViewModel(
-                analyticsLogger = FakeAnalyticsLogger(),
-                resourceProvider = resourceProvider,
+                analytics = mock<ResumeAnalytics>(),
                 sessionReader = StubSessionReader(),
                 logger = SystemLogger(),
             ),

--- a/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityViewModelTest.kt
+++ b/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityViewModelTest.kt
@@ -15,6 +15,7 @@ import uk.gov.logging.api.v3dot1.model.AnalyticsEvent
 import uk.gov.logging.api.v3dot1.model.RequiredParameters
 import uk.gov.logging.api.v3dot1.model.TrackEvent
 import uk.gov.logging.testdouble.SystemLogger
+import uk.gov.onelogin.criorchestrator.features.resume.internal.analytics.ResumeAnalytics
 import uk.gov.onelogin.criorchestrator.features.session.internal.StubSessionReader
 import uk.gov.onelogin.criorchestrator.libraries.androidutils.resources.FakeResourceProvider
 import uk.gov.onelogin.criorchestrator.libraries.testing.MainDispatcherExtension
@@ -25,8 +26,11 @@ class ProveYourIdentityViewModelTest {
 
     private val viewModel by lazy {
         ProveYourIdentityViewModel(
-            analyticsLogger = analyticsLogger,
-            resourceProvider = FakeResourceProvider(),
+            analytics =
+                ResumeAnalytics(
+                    resourceProvider = FakeResourceProvider(),
+                    analyticsLogger = analyticsLogger,
+                ),
             sessionReader = StubSessionReader(),
             logger = SystemLogger(),
         )


### PR DESCRIPTION
## Change

Extract analytics for the 'resume' feature into it's own class.

## Context

- Enables analytics functionality to be shared across screens within the feature.
- Reduces risk of bugs in Welsh language mode.
- Avoids polluting view models with low level analytics details.

DCMAW-10056

## Evidence of the change

N/A

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
