### PR TITLE
fix: update pages to patterns in FullScreenDialog import path

### DIFF
--- a/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/devmenu/DevMenuDialog.kt
+++ b/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/devmenu/DevMenuDialog.kt
@@ -3,7 +3,7 @@ package uk.gov.onelogin.criorchestrator.testwrapper.devmenu
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import uk.gov.android.ui.pages.dialog.FullScreenDialog
+import uk.gov.android.ui.patterns.dialog.FullScreenDialog
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.onelogin.criorchestrator.features.dev.publicapi.DevMenuScreen
 import uk.gov.onelogin.criorchestrator.sdk.sharedapi.CriOrchestratorComponent


### PR DESCRIPTION
- fix incorrect path for `FullScreenDialog` import by updating `pages` to `patterns` to align with UI repo.
- this was causing code to fail compilation

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
