### PR TITLE
fix: Fix scope of config store

### DIFF
--- a/features/config/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/config/internal/InMemoryConfigStore.kt
+++ b/features/config/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/config/internal/InMemoryConfigStore.kt
@@ -11,9 +11,11 @@ import uk.gov.logging.api.Logger
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.ConfigKey
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.ConfigStore
+import uk.gov.onelogin.criorchestrator.libraries.di.ActivityScope
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 import javax.inject.Inject
 
+@ActivityScope
 @ContributesBinding(CriOrchestratorScope::class, boundType = ConfigStore::class)
 class InMemoryConfigStore
     @Inject


### PR DESCRIPTION
## Changes

Fix scope of the `InMemoryConfigStore`, which should have only a single instance within the SDK scope (`@ActivityScope`).

## Context

DCMAW-11697

## Evidence of the change

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
