### PR TITLE
refactor: Convert 'select passport' screen to use slot-based pattern

### DIFF
--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportScreen.kt
@@ -1,6 +1,14 @@
+@file:OptIn(UnstableDesignSystemAPI::class)
+
 package uk.gov.onelogin.criorchestrator.features.selectdoc.internal.passport
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -8,21 +16,23 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
+import uk.gov.android.ui.componentsv2.button.ButtonType
+import uk.gov.android.ui.componentsv2.button.GdsButton
+import uk.gov.android.ui.componentsv2.heading.GdsHeading
+import uk.gov.android.ui.componentsv2.inputs.radio.GdsSelection
 import uk.gov.android.ui.componentsv2.inputs.radio.RadioSelectionTitle
 import uk.gov.android.ui.componentsv2.inputs.radio.TitleType
 import uk.gov.android.ui.patterns.leftalignedscreen.LeftAlignedScreen
-import uk.gov.android.ui.patterns.leftalignedscreen.LeftAlignedScreenBody.Image
-import uk.gov.android.ui.patterns.leftalignedscreen.LeftAlignedScreenBody.SecondaryButton
-import uk.gov.android.ui.patterns.leftalignedscreen.LeftAlignedScreenBody.Selection
-import uk.gov.android.ui.patterns.leftalignedscreen.LeftAlignedScreenBody.Text
-import uk.gov.android.ui.patterns.leftalignedscreen.LeftAlignedScreenButton
 import uk.gov.android.ui.theme.m3.GdsTheme
+import uk.gov.android.ui.theme.util.UnstableDesignSystemAPI
 import uk.gov.onelogin.criorchestrator.features.selectdoc.internal.R
 import uk.gov.onelogin.criorchestrator.features.selectdoc.internalapi.nav.SelectDocumentDestinations
 import uk.gov.onelogin.criorchestrator.libraries.composeutils.LightDarkBothLocalesPreview
@@ -72,8 +82,9 @@ internal fun SelectPassportScreen(
     )
 }
 
+@OptIn(UnstableDesignSystemAPI::class)
+@Suppress("LongMethod", "LongParameterList")
 @Composable
-@Suppress("LongParameterList")
 internal fun SelectPassportScreenContent(
     title: String,
     readMoreButtonTitle: String,
@@ -84,48 +95,81 @@ internal fun SelectPassportScreenContent(
     modifier: Modifier = Modifier,
 ) {
     var selectedItem by remember { mutableStateOf<Int?>(null) }
-    LeftAlignedScreen(
-        title = title,
+    Surface(
         modifier = modifier,
-        body =
-            persistentListOf(
-                Text(
-                    stringResource(R.string.selectdocument_passport_body),
-                ),
-                Image(
-                    image = R.drawable.nfc_passport,
-                    contentDescription = stringResource(R.string.selectdocument_passport_imagedescription),
-                    Modifier.fillMaxWidth(),
-                ),
-                Text(stringResource(R.string.selectdocument_passport_expiry)),
-                SecondaryButton(
-                    text = readMoreButtonTitle,
-                    onClick = onReadMoreClick,
-                ),
-                Selection(
-                    title =
-                        RadioSelectionTitle(
-                            stringResource(R.string.selectdocument_passport_title),
-                            TitleType.Heading,
-                        ),
-                    items = items,
-                    selectedItem = selectedItem,
-                    onItemSelected = {
-                        selectedItem = it
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        LeftAlignedScreen(
+            title = { horizontalPadding ->
+                GdsHeading(
+                    text = title,
+                    modifier = Modifier.padding(horizontal = horizontalPadding),
+                )
+            },
+            body = { horizontalPadding ->
+                item {
+                    Text(
+                        text = stringResource(R.string.selectdocument_passport_body),
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(horizontal = horizontalPadding),
+                    )
+                }
+                item {
+                    Image(
+                        painter = painterResource(R.drawable.nfc_passport),
+                        contentDescription = stringResource(R.string.selectdocument_passport_imagedescription),
+                        modifier = Modifier.fillMaxWidth(),
+                        contentScale = ContentScale.FillWidth,
+                    )
+                }
+                item {
+                    Text(
+                        text = stringResource(R.string.selectdocument_passport_expiry),
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(horizontal = horizontalPadding),
+                    )
+                }
+                item {
+                    GdsButton(
+                        text = readMoreButtonTitle,
+                        buttonType = ButtonType.Secondary,
+                        onClick = onReadMoreClick,
+                        modifier = Modifier.padding(horizontal = horizontalPadding),
+                        contentModifier = Modifier,
+                        textAlign = TextAlign.Left,
+                        contentPosition = Arrangement.Start,
+                    )
+                }
+                item {
+                    GdsSelection(
+                        title =
+                            RadioSelectionTitle(
+                                stringResource(R.string.selectdocument_passport_title),
+                                TitleType.Heading,
+                            ),
+                        items = items,
+                        selectedItem = selectedItem,
+                        onItemSelected = {
+                            selectedItem = it
+                        },
+                    )
+                }
+            },
+            primaryButton = {
+                GdsButton(
+                    text = confirmButtonText,
+                    buttonType = ButtonType.Primary,
+                    onClick = {
+                        selectedItem?.let {
+                            onConfirmSelection(it)
+                        }
                     },
-                ),
-            ),
-        primaryButton =
-            LeftAlignedScreenButton(
-                text = confirmButtonText,
-                onClick = {
-                    selectedItem?.let {
-                        onConfirmSelection(it)
-                    }
-                },
-                enabled = selectedItem != null,
-            ),
-    )
+                    enabled = selectedItem != null,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            },
+        )
+    }
 }
 
 @LightDarkBothLocalesPreview

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ testparameterinjector = "1.18"
 turbine = "1.2.0"
 uk-gov-logging = "0.19.0" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.3.4"
-uk-gov-ui = "7.12.0"
+uk-gov-ui = "7.13.1"
 gov-uk-idcheck = "0.6.73"
 
 [libraries]


### PR DESCRIPTION
## Context

DCMAW-8054

https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/183#discussion_r1995327520

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
