### PR TITLE
test: Check module architecture

### DIFF
--- a/konsist-test/src/test/kotlin/uk/gov/onelogin/criorchestrator/konsisttest/ModuleArchitectureTest.kt
+++ b/konsist-test/src/test/kotlin/uk/gov/onelogin/criorchestrator/konsisttest/ModuleArchitectureTest.kt
@@ -1,0 +1,94 @@
+package uk.gov.onelogin.criorchestrator.konsisttest
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.Konsist.scopeFromTest
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.jupiter.api.Test
+import uk.gov.onelogin.criorchestrator.konsisttest.filters.hasPackageMatching
+import uk.gov.onelogin.criorchestrator.konsisttest.filters.withPackageMatching
+import uk.gov.onelogin.criorchestrator.konsisttest.scopes.defaultScope
+
+class ModuleArchitectureTest {
+    companion object {
+        private val libraryPackage = """uk\.gov\..*\.libraries\..*""".toRegex()
+        private val featurePackageAny =
+            """(uk\.gov\..*\.features\..*)\.(?:internal|internalapi|publicapi|)(?:\..*|$)""".toRegex()
+        private val featurePackageInternal =
+            """(uk\.gov\..*\.features\..*)\.internal(?:\..*|$)""".toRegex()
+        private val featurePackageApi =
+            """(uk\.gov\..*\.features\..*)\.(:?internalapi|publicapi)(?:\..*|$)""".toRegex()
+    }
+
+    @Test
+    fun `feature modules have valid package names`() {
+        val potentialFeaturePackage =
+            "uk\\.gov\\..*\\.features\\..*".toRegex()
+        Konsist
+            .defaultScope()
+            .files
+            .withPackageMatching(potentialFeaturePackage)
+            .assertTrue {
+                it.hasPackageMatching(featurePackageAny)
+            }
+    }
+
+    @Test
+    fun `feature modules do not depend directly on other features internals`() {
+        Konsist
+            .defaultScope()
+            .minus(scope = scopeFromTest())
+            .files
+            .withPackageMatching(featurePackageAny)
+            .assertTrue(
+                additionalMessage =
+                    """
+                    Features should depend on each other indirectly, through API modules.
+                    Implementations should be injected.
+                    """.trimIndent(),
+            ) {
+                val thisFeaturePackage =
+                    featurePackageAny.find(it.packagee!!.text)!!.groupValues[1]
+                it.imports
+                    .filter {
+                        !it.hasNameStartingWith(thisFeaturePackage)
+                    }.none {
+                        it.hasNameMatching(featurePackageInternal)
+                    }
+            }
+    }
+
+    @Test
+    fun `api modules do not contain implementations`() {
+        Konsist
+            .defaultScope()
+            .minus(scope = scopeFromTest())
+            .files
+            .withPackageMatching(featurePackageApi)
+            .assertTrue(
+                additionalMessage =
+                    """
+                    Implementations should live in a feature's internal module.
+                    Only interfaces data structures should be exposed through API modules.
+                    """.trimIndent(),
+            ) {
+                it.classes().all {
+                    it.hasAbstractModifier ||
+                        it.hasDataModifier ||
+                        it.hasEnumModifier
+                }
+            }
+    }
+
+    @Test
+    fun `library modules do not depend on feature modules`() {
+        Konsist
+            .defaultScope()
+            .files
+            .withPackageMatching(libraryPackage)
+            .assertTrue {
+                it.imports.none {
+                    it.hasNameMatching(featurePackageAny)
+                }
+            }
+    }
+}

--- a/konsist-test/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/konsisttest/filters/FileFilters.kt
+++ b/konsist-test/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/konsisttest/filters/FileFilters.kt
@@ -1,0 +1,10 @@
+package uk.gov.onelogin.criorchestrator.konsisttest.filters
+
+import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
+
+fun List<KoFileDeclaration>.withPackageMatching(regex: Regex) =
+    filter {
+        it.hasPackageMatching(regex)
+    }
+
+fun KoFileDeclaration.hasPackageMatching(regex: Regex) = packagee?.hasNameMatching(regex) == true


### PR DESCRIPTION
## Changes

Add checks for correct module naming, dependencies and contents.

## Context

DCMAW-8900

Prompted by initial navigation implementation (#190) that created an invalid dependency between modules: https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/190/commits/a89e5ccf7983a93365ba4e6ae0b8e02cb42d78cc#diff-6ae191f7b7648adbcdc1314fd9c8ac0dc7e8cf825804b475b17a200e11e2d05eL16.

Currently it's possible to create features that bypass the feature module architecture so that `internal` modules depend on one another directly. This check guards against this and gives a hint on how to proceed.

## Evidence of the change

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [x] Add automated tests
- [x] Self-review code
