### PR TITLE
fix: Remove test fixtures dependency from debug build

### DIFF
--- a/features/resume/internal/build.gradle.kts
+++ b/features/resume/internal/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation(project(":libraries:di"))
     implementation(project(":libraries:navigation"))
 
-    debugImplementation(testFixtures(project(":libraries:analytics")))
+    testImplementation(testFixtures(project(":libraries:analytics")))
 
     testImplementation(libs.uk.gov.logging.testdouble)
     testImplementation(testFixtures(project(":features:session:internal")))

--- a/features/select-doc/internal/build.gradle.kts
+++ b/features/select-doc/internal/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation(project(":libraries:di"))
     implementation(project(":libraries:navigation"))
 
-    debugImplementation(testFixtures(project(":libraries:analytics")))
+    testImplementation(testFixtures(project(":libraries:analytics")))
 
     testImplementation(libs.uk.gov.logging.testdouble)
 }


### PR DESCRIPTION
## Changes

Remove dependency on test fixtures from debug build.

## Context

Currently debug test fixtures are not published and only release test fixtures are published. This is a separate issue, but what it means is that the debug build can't depend on test fixtures without pointing at the release configuration.

This change works around the issue by removing the dependency between the debug build and test fixtures. These test fixtures weren't used in non-test code anyway, so this is the way it should have been set up to start with.

The build error that this fixes is as follows:

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':app:dataBindingGenBaseClassesBuildDebug'.
> Could not resolve all dependencies for configuration ':app:buildDebugRuntimeClasspath'.
   > Could not resolve uk.gov.onelogin.criorchestrator.libraries:analytics:0.19.1.
     Required by:
         project :app > uk.gov.onelogin.criorchestrator.sdk:sdk:0.19.1 > uk.gov.onelogin.criorchestrator.sdk:sdk-internal:0.19.1 > uk.gov.onelogin.criorchestrator.features:resume-internal:0.19.1
         project :app > uk.gov.onelogin.criorchestrator.sdk:sdk:0.19.1 > uk.gov.onelogin.criorchestrator.sdk:sdk-internal:0.19.1 > uk.gov.onelogin.criorchestrator.features:select-doc-internal:0.19.1
      > Unable to find a variant providing the requested capability 'uk.gov.onelogin.criorchestrator.libraries:analytics-test-fixtures':
           - Variant 'debugTestFixturesVariantDefaultApiPublication' provides 'mobile-android-cri-orchestrator.libraries:analytics-test-fixtures:unspecified'
           - Variant 'debugTestFixturesVariantDefaultRuntimePublication' provides 'mobile-android-cri-orchestrator.libraries:analytics-test-fixtures:unspecified'
           - Variant 'debugVariantDefaultApiPublication' provides 'uk.gov.onelogin.criorchestrator.libraries:analytics:0.19.1'
           - Variant 'debugVariantDefaultJavaDocPublication' provides 'uk.gov.onelogin.criorchestrator.libraries:analytics:0.19.1'
           - Variant 'debugVariantDefaultRuntimePublication' provides 'uk.gov.onelogin.criorchestrator.libraries:analytics:0.19.1'
           - Variant 'debugVariantDefaultSourcePublication' provides 'uk.gov.onelogin.criorchestrator.libraries:analytics:0.19.1'
           - Variant 'releaseTestFixturesVariantDefaultApiPublication' provides 'mobile-android-cri-orchestrator.libraries:analytics-test-fixtures:unspecified'
           - Variant 'releaseTestFixturesVariantDefaultRuntimePublication' provides 'mobile-android-cri-orchestrator.libraries:analytics-test-fixtures:unspecified'
           - Variant 'releaseVariantDefaultApiPublication' provides 'uk.gov.onelogin.criorchestrator.libraries:analytics:0.19.1'
           - Variant 'releaseVariantDefaultJavaDocPublication' provides 'uk.gov.onelogin.criorchestrator.libraries:analytics:0.19.1'
           - Variant 'releaseVariantDefaultRuntimePublication' provides 'uk.gov.onelogin.criorchestrator.libraries:analytics:0.19.1'
           - Variant 'releaseVariantDefaultSourcePublication' provides 'uk.gov.onelogin.criorchestrator.libraries:analytics:0.19.1'
```

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
