### PR TITLE
refactor: Extract constants from 'select passport' screen state

### DIFF
--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportConstants.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportConstants.kt
@@ -1,0 +1,12 @@
+package uk.gov.onelogin.criorchestrator.features.selectdoc.internal.passport
+
+import androidx.annotation.StringRes
+import uk.gov.onelogin.criorchestrator.features.selectdoc.internal.R
+
+internal object SelectPassportConstants {
+    @StringRes val titleId: Int = R.string.selectdocument_passport_title
+
+    @StringRes val readMoreButtonTextId: Int = R.string.selectdocument_passport_readmore_button
+
+    @StringRes val buttonTextId: Int = R.string.selectdocument_passport_continuebutton
+}

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportScreen.kt
@@ -59,15 +59,15 @@ internal fun SelectPassportScreen(
     }
 
     SelectPassportScreenContent(
-        title = stringResource(state.titleId),
+        title = stringResource(SelectPassportConstants.titleId),
         modifier = modifier,
-        readMoreButtonTitle = stringResource(state.readMoreButtonTextId),
+        readMoreButtonTitle = stringResource(SelectPassportConstants.readMoreButtonTextId),
         onReadMoreClick = viewModel::onReadMoreClick,
         items =
             state.options
                 .map { stringResource(it) }
                 .toPersistentList(),
-        confirmButtonText = stringResource(state.buttonTextId),
+        confirmButtonText = stringResource(SelectPassportConstants.buttonTextId),
         onConfirmSelection = viewModel::onConfirmSelection,
     )
 }

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportState.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportState.kt
@@ -1,11 +1,7 @@
 package uk.gov.onelogin.criorchestrator.features.selectdoc.internal.passport
 
-import androidx.annotation.StringRes
 import kotlinx.collections.immutable.PersistentList
 
 data class SelectPassportState(
-    @StringRes val titleId: Int,
-    @StringRes val readMoreButtonTextId: Int,
     val options: PersistentList<Int>,
-    @StringRes val buttonTextId: Int,
 )

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportViewModel.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportViewModel.kt
@@ -18,14 +18,11 @@ internal class SelectPassportViewModel(
     private val _state =
         MutableStateFlow(
             SelectPassportState(
-                titleId = R.string.selectdocument_passport_title,
-                readMoreButtonTextId = R.string.selectdocument_passport_readmore_button,
                 options =
                     persistentListOf(
                         R.string.selectdocument_passport_selection_yes,
                         R.string.selectdocument_passport_selection_no,
                     ),
-                buttonTextId = R.string.selectdocument_passport_continuebutton,
             ),
         )
     val state: StateFlow<SelectPassportState> = _state
@@ -35,13 +32,13 @@ internal class SelectPassportViewModel(
 
     fun onScreenStart() {
         analytics.trackScreen(
-            SelectDocumentScreenId.SelectPassport,
-            state.value.titleId,
+            id = SelectDocumentScreenId.SelectPassport,
+            title = SelectPassportConstants.titleId,
         )
     }
 
     fun onReadMoreClick() {
-        analytics.trackButtonEvent(state.value.readMoreButtonTextId)
+        analytics.trackButtonEvent(buttonText = SelectPassportConstants.readMoreButtonTextId)
         viewModelScope.launch {
             _actions.emit(SelectPassportAction.NavigateToTypesOfPhotoID)
         }
@@ -49,7 +46,7 @@ internal class SelectPassportViewModel(
 
     fun onConfirmSelection(selectedIndex: Int) {
         analytics.trackFormSubmission(
-            buttonText = state.value.buttonTextId,
+            buttonText = SelectPassportConstants.buttonTextId,
             response = state.value.options[selectedIndex],
         )
 


### PR DESCRIPTION
## Changes

Extract constants from 'select passport' screen state.

## Context

- Addresses review comment: https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/195#discussion_r2005773517

## Evidence of the change

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
