### PR TITLE
ci: Fix `publish-packages` workflow when version is not bumped

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -47,10 +47,11 @@ jobs:
           version-prefix: ''
 
       - name: Create workflow outputs
-        if: ${{ steps.versioning.outputs.current_version != steps.versioning.outputs.new_version }}
+        env:
+          VERSION_BUMPED: ${{ steps.versioning.outputs.current_version != steps.versioning.outputs.new_version }}
         run: |
           mkdir "$WORKFLOW_OUT_DIR" && touch "$WORKFLOW_OUT_DIR/bump-version.yml"
-          yq -i '.version-bumped = true' "$WORKFLOW_OUT_DIR/bump-version.yml"
+          yq -i ".version-bumped = $VERSION_BUMPED" "$WORKFLOW_OUT_DIR/bump-version.yml"
         shell: bash
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## Changes

Fix the `publish-packages` workflow when version is not bumped by ensuring the `bump-version` workflow always creates outputs.

## Context

https://github.com/govuk-one-login/mobile-android-cri-orchestrator/actions/runs/14084037440

```
Publish packages
Unable to download artifact(s): Artifact not found for name: bump-version-outputs
```

DCMAW-12335

## Evidence of the change

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
