### PR TITLE
ci: Add dependabot group for `uk.gov` dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ version: 2
 registries:
   github-maven:
     type: maven-repository
-    url: https://maven.pkg.github.com
+    url: https://maven.pkg.github.com/govuk-one-login
     username: ${{ secrets.MODULE_FETCH_TOKEN_USERNAME }}
     password: ${{ secrets.MODULE_FETCH_TOKEN }}
 updates:


### PR DESCRIPTION
## Changes

- Add a dependabot group for `uk.gov` dependencies
- Update the maven repository base URL to include `/govuk-one-login`

## Context

DCMAW-12232

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
