### PR TITLE
ci: Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ version: 2
 registries:
   github-maven:
     type: maven-repository
-    url: https://maven.pkg.github.com/govuk-one-login
+    url: https://maven.pkg.github.com/govuk-one-login/*
     username: ${{ secrets.MODULE_FETCH_TOKEN_USERNAME }}
     password: ${{ secrets.MODULE_FETCH_TOKEN }}
 updates:


### PR DESCRIPTION
## Context

DCMAW-12232

## Evidence of the change

Having tested this manually, it seems the maven repo URL is wrong.


### Current repo URL

Visiting `https://maven.pkg.github.com/govuk-one-login/uk/gov/logging/logging-api/maven-metadata.xml`

```
unable to fetch maven-metadata for package : "maven package "gov.logging.logging-api" does not exist under owner "govuk-one-login""
```

### New repo URL
Visiting `https://maven.pkg.github.com/govuk-one-login/*/uk/gov/logging/logging-api/maven-metadata.xml`

```
<metadata>
<groupId>uk.gov.logging</groupId>
<artifactId>logging-api</artifactId>
<versioning>
<latest>0.20.0</latest>
...
```
 
[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
