### PR TITLE
test: Allow custom light dark preview annotations

### DIFF
--- a/konsist-test/src/test/kotlin/uk/gov/onelogin/criorchestrator/konsisttest/ComposePreviewsKonsistTest.kt
+++ b/konsist-test/src/test/kotlin/uk/gov/onelogin/criorchestrator/konsisttest/ComposePreviewsKonsistTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.onelogin.criorchestrator.konsisttest
 
 import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.declaration.KoArgumentDeclaration
+import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
 import com.lemonappdev.konsist.api.verify.assertFalse
 import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.jupiter.api.Test
@@ -26,7 +28,22 @@ class ComposePreviewsKonsistTest {
             .functions()
             .withComposablePreviewAnnotations()
             .assertTrue {
-                it.hasAnnotationWithName("PreviewLightDark") || it.hasAnnotationWithName("LightDarkBothLocalesPreview")
+                it.hasAnnotationWithName("PreviewLightDark") ||
+                    it.hasAnnotationWithName("LightDarkBothLocalesPreview") ||
+                    it.hasCustomLightDarkPreviewAnnotations()
             }
     }
+}
+
+private fun KoAnnotationProvider.hasCustomLightDarkPreviewAnnotations() =
+    hasAnnotation {
+        it.name == "Preview" && it.hasArgument { it.hasUiModeNightEnabled() }
+    } &&
+        hasAnnotation {
+            it.name == "Preview" && it.hasArgument { !it.hasUiModeNightEnabled() }
+        }
+
+@Suppress("ktlint:standard:function-expression-body")
+private fun KoArgumentDeclaration.hasUiModeNightEnabled(): Boolean {
+    return name == "uiMode" && value!!.contains("UI_MODE_NIGHT_YES")
 }


### PR DESCRIPTION
## Changes

Allow use of Compose `@Preview` annotations when creating light and dark mode previews.

## Context

Sometimes screens need to pass custom parameters to `@Preview` annotations. However the existing lint rule required that light and dark previews used custom annotations such as `@PreviewLightDark`. This change enables either usage.

DCMAW-8796

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
