### PR TITLE
build: Increase JVM heap size to 4GB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
## Changes

Increase JVM heap size to 4GB

## Context

DCMAW-12366

https://github.com/govuk-one-login/mobile-android-cri-orchestrator/actions/runs/14104361787/job/39507412036?pr=226

```
 > Task :sdk:internal:bundleLibRuntimeToDirDebugTestFixtures
ERROR: D8: java.lang.OutOfMemoryError: Java heap space
```

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
