### PR TITLE
test: Fix Imposter running under custom root project directory

### DIFF
--- a/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/imposter-test-config.gradle.kts
+++ b/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/imposter-test-config.gradle.kts
@@ -5,6 +5,13 @@ import uk.gov.onelogin.criorchestrator.extensions.imposterTestDependencies
 
 val libs = the<LibrariesForLibs>()
 
+tasks.withType<Test> {
+    systemProperty(
+        "uk.gov.onelogin.criorchestrator.imposterConfigDir",
+        rootProject.file("config/imposter/")
+    )
+}
+
 dependencies {
     imposterTestDependencies(libs)
 }

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
@@ -29,7 +29,7 @@ class IntegrationTest {
     private val fakeConfigStore = FakeConfigStore()
     private val logger = SystemLogger()
     private val dispatchers = CoroutineDispatchers.from(UnconfinedTestDispatcher())
-    private val imposter = Imposter().createImposterBackend()
+    private val imposter = Imposter.createMockEngine()
 
     private lateinit var sessionApiImpl: SessionApi
     private lateinit var remoteSessionReader: RemoteSessionReader

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/SessionApiImplTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/SessionApiImplTest.kt
@@ -18,7 +18,7 @@ class SessionApiImplTest {
 
     @BeforeEach
     fun setup() {
-        val imposter = Imposter().createImposterBackend()
+        val imposter = Imposter.createMockEngine()
         fakeConfigStore.write(
             Config.Entry(
                 key = SdkConfigKey.IdCheckAsyncBackendBaseUrl,

--- a/libraries/testing/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/libraries/testing/networking/Imposter.kt
+++ b/libraries/testing/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/libraries/testing/networking/Imposter.kt
@@ -3,20 +3,13 @@ package uk.gov.onelogin.criorchestrator.libraries.testing.networking
 import io.gatehill.imposter.openapi.embedded.OpenApiImposterBuilder
 import io.gatehill.imposter.openapi.embedded.OpenApiMockEngine
 
-class Imposter {
-    val currentDir: String? = System.getProperty("user.dir")
-    val rootSubstring = "mobile-android-cri-orchestrator"
-    val path =
-        currentDir
-            ?.substring(
-                0,
-                currentDir.lastIndexOf(rootSubstring) + rootSubstring.length,
-            ) + "/config/imposter"
+private const val CONFIG_DIR_PROPERTY = "uk.gov.onelogin.criorchestrator.imposterConfigDir"
 
-    class OpenApiImposterBuilderImpl : OpenApiImposterBuilder<OpenApiMockEngine, OpenApiImposterBuilderImpl>()
-
-    fun createImposterBackend(): OpenApiMockEngine =
+object Imposter {
+    fun createMockEngine(): OpenApiMockEngine =
         OpenApiImposterBuilderImpl()
-            .withConfigurationDir(path)
+            .withConfigurationDir(System.getProperty(CONFIG_DIR_PROPERTY))
             .startBlocking()
 }
+
+private class OpenApiImposterBuilderImpl : OpenApiImposterBuilder<OpenApiMockEngine, OpenApiImposterBuilderImpl>()


### PR DESCRIPTION
## Changes

Fix issue where imposter tests fail when the root project directory is not the same as the Github repository name.

## Context

Before this change, if a developer had cloned the project into a custom directory (for example, I use `cri-orchestrator`), the Imposter tests would fail.

DCMAW-12386

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
