### PR TITLE
ci: Group Android Gradle Plugin dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,11 @@ updates:
     commit-message:
       prefix: "build"
     groups:
+      agp:
+        patterns:
+          - "com.android.tools.build"
+          - "com.android.application"
+          - "com.android.library"
       kotlin:
         patterns:
           - "org.jetbrains.kotlin*"


### PR DESCRIPTION
## Changes

Group Android Gradle Plugin (AGP) dependabot updates.

## Context

AGP updates often cause the build to break. In a recent example (#233), AGP 8.9.x is causing problems and needs manual work to fix the build. Separating AGP updates helps other dependency updates to progress without being blocked.

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
