### PR TITLE
ci: Fix dependabot group pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,9 +37,9 @@ updates:
     groups:
       agp:
         patterns:
-          - "com.android.tools.build"
-          - "com.android.application"
-          - "com.android.library"
+          - "com.android.tools.build*"
+          - "com.android.application*"
+          - "com.android.library*"
       kotlin:
         patterns:
           - "org.jetbrains.kotlin*"


### PR DESCRIPTION
## Context

Android Gradle Plugin included in wrong group: https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/245

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
