### PR TITLE
fix: make redirect_uri parameter optional- this is not required for desktop users

### DIFF
--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/RemoteSessionReader.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/RemoteSessionReader.kt
@@ -36,6 +36,12 @@ class RemoteSessionReader
         private val logger: Logger,
     ) : SessionReader,
         LogTagProvider {
+        private val json: Json by lazy {
+            Json {
+                ignoreUnknownKeys = true
+            }
+        }
+
         override fun isActiveSession(): Flow<Boolean> =
             merge(
                 configStore.read(IdCheckAsyncBackendBaseUrl),
@@ -61,7 +67,7 @@ class RemoteSessionReader
 
             return try {
                 val parsedResponse: ActiveSessionApiResponse.ActiveSessionSuccess =
-                    Json.decodeFromString(response.response.toString())
+                    json.decodeFromString(response.response.toString())
                 Session(
                     sessionId = parsedResponse.sessionId,
                     redirectUri = parsedResponse.redirectUri,

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/response/ActiveSessionApiResponse.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/response/ActiveSessionApiResponse.kt
@@ -11,7 +11,7 @@ sealed class ActiveSessionApiResponse {
         @JsonNames("sessionId")
         val sessionId: String,
         @JsonNames("redirectUri")
-        val redirectUri: String,
+        val redirectUri: String? = null,
         @JsonNames("state")
         val state: String,
     ) : ActiveSessionApiResponse()

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
@@ -102,12 +102,46 @@ class RemoteSessionReaderTest {
                 arguments(
                     named(
                         "true with expected log entry when API response is Success with correct" +
-                            "response format",
+                            "response format - with redirectUri (mobile journey)",
                         ApiResponse.Success<String>(
                             """
                             {
                                 "sessionId": "test session ID",
                                 "redirectUri": "https://example/redirect",
+                                "state": "11112222333344445555666677778888"
+                            }
+                            """.trimIndent(),
+                        ),
+                    ),
+                    "Got active session",
+                    true,
+                ),
+                arguments(
+                    named(
+                        "true with expected log entry when API response is Success with correct" +
+                            "response format - with new parameters",
+                        ApiResponse.Success<String>(
+                            """
+                            {
+                                "sessionId": "test session ID",
+                                "redirectUri": "https://example/redirect",
+                                "additionalParameter": true,
+                                "state": "11112222333344445555666677778888"
+                            }
+                            """.trimIndent(),
+                        ),
+                    ),
+                    "Got active session",
+                    true,
+                ),
+                arguments(
+                    named(
+                        "true with expected log entry when API response is Success with correct" +
+                            "response format - no redirectUri (desktop journey)",
+                        ApiResponse.Success<String>(
+                            """
+                            {
+                                "sessionId": "test session ID",
                                 "state": "11112222333344445555666677778888"
                             }
                             """.trimIndent(),


### PR DESCRIPTION
# DCMAW-12479: make `redirect_uri` parameter optional

## Evidence of the change

- covered by new unit tests: [RemoteSessionReaderTest.kt](https://github.com/govuk-one-login/mobile-android-cri-orchestrator/blob/dc955355e178a4c19782b2509379a66a2a6ced53/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt)

## Checklist

- [x] Check against acceptance criteria
- [x] Add automated tests
- [x] Self-review code
