### PR TITLE
refactor: make select passport code consistent with select brp

### DIFF
--- a/features/select-doc/internal-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internalapi/nav/SelectDocumentDestinations.kt
+++ b/features/select-doc/internal-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internalapi/nav/SelectDocumentDestinations.kt
@@ -17,5 +17,5 @@ sealed interface SelectDocumentDestinations : ProveYourIdentityDestinations {
     data object TypesOfPhotoID : SelectDocumentDestinations
 
     @Serializable
-    data object Confirm : SelectDocumentDestinations
+    data object ConfirmPassport : SelectDocumentDestinations
 }

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/SelectDocumentNavGraphProvider.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/SelectDocumentNavGraphProvider.kt
@@ -50,7 +50,7 @@ class SelectDocumentNavGraphProvider
                 )
             }
 
-            composable<SelectDocumentDestinations.Confirm> {
+            composable<SelectDocumentDestinations.ConfirmPassport> {
                 ConfirmDocumentScreen()
             }
         }

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportConstants.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportConstants.kt
@@ -1,12 +1,23 @@
 package uk.gov.onelogin.criorchestrator.features.selectdoc.internal.passport
 
 import androidx.annotation.StringRes
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import uk.gov.onelogin.criorchestrator.features.selectdoc.internal.R
 
 internal object SelectPassportConstants {
-    @StringRes val titleId: Int = R.string.selectdocument_passport_title
+    @StringRes
+    val titleId: Int = R.string.selectdocument_passport_title
 
-    @StringRes val readMoreButtonTextId: Int = R.string.selectdocument_passport_readmore_button
+    @StringRes
+    val readMoreButtonTextId: Int = R.string.selectdocument_passport_readmore_button
 
-    @StringRes val buttonTextId: Int = R.string.selectdocument_passport_continuebutton
+    @StringRes
+    val buttonTextId: Int = R.string.selectdocument_passport_continuebutton
+
+    val options: ImmutableList<Int> =
+        persistentListOf(
+            R.string.selectdocument_passport_selection_yes,
+            R.string.selectdocument_passport_selection_no,
+        )
 }

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportScreen.kt
@@ -18,9 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
-import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import uk.gov.android.ui.componentsv2.button.ButtonType
 import uk.gov.android.ui.componentsv2.button.GdsButton
@@ -42,8 +40,6 @@ internal fun SelectPassportScreen(
     navController: NavController,
     modifier: Modifier = Modifier,
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
-
     LaunchedEffect(Unit) {
         viewModel.onScreenStart()
 
@@ -56,7 +52,7 @@ internal fun SelectPassportScreen(
 
                 SelectPassportAction.NavigateToConfirmation ->
                     navController.navigate(
-                        SelectDocumentDestinations.Confirm,
+                        SelectDocumentDestinations.ConfirmPassport,
                     )
 
                 SelectPassportAction.NavigateToBrp ->
@@ -68,15 +64,8 @@ internal fun SelectPassportScreen(
     }
 
     SelectPassportScreenContent(
-        title = stringResource(SelectPassportConstants.titleId),
         modifier = modifier,
-        readMoreButtonTitle = stringResource(SelectPassportConstants.readMoreButtonTextId),
         onReadMoreClick = viewModel::onReadMoreClick,
-        items =
-            state.options
-                .map { stringResource(it) }
-                .toPersistentList(),
-        confirmButtonText = stringResource(SelectPassportConstants.buttonTextId),
         onConfirmSelection = viewModel::onConfirmSelection,
     )
 }
@@ -85,11 +74,7 @@ internal fun SelectPassportScreen(
 @Suppress("LongMethod", "LongParameterList")
 @Composable
 internal fun SelectPassportScreenContent(
-    title: String,
-    readMoreButtonTitle: String,
     onReadMoreClick: () -> Unit,
-    items: PersistentList<String>,
-    confirmButtonText: String,
     onConfirmSelection: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -101,7 +86,7 @@ internal fun SelectPassportScreenContent(
         LeftAlignedScreen(
             title = { horizontalPadding ->
                 GdsHeading(
-                    text = title,
+                    text = stringResource(SelectPassportConstants.titleId),
                     modifier = Modifier.padding(horizontal = horizontalPadding),
                 )
             },
@@ -128,7 +113,7 @@ internal fun SelectPassportScreenContent(
                 }
                 item {
                     GdsButton(
-                        text = readMoreButtonTitle,
+                        text = stringResource(SelectPassportConstants.readMoreButtonTextId),
                         buttonType = ButtonType.Secondary,
                         onClick = onReadMoreClick,
                         modifier = Modifier.padding(horizontal = horizontalPadding),
@@ -144,7 +129,10 @@ internal fun SelectPassportScreenContent(
                                 stringResource(R.string.selectdocument_passport_title),
                                 TitleType.Heading,
                             ),
-                        items = items,
+                        items =
+                            SelectPassportConstants.options
+                                .map { stringResource(it) }
+                                .toPersistentList(),
                         selectedItem = selectedItem,
                         onItemSelected = {
                             selectedItem = it
@@ -154,7 +142,7 @@ internal fun SelectPassportScreenContent(
             },
             primaryButton = {
                 GdsButton(
-                    text = confirmButtonText,
+                    text = stringResource(SelectPassportConstants.buttonTextId),
                     buttonType = ButtonType.Primary,
                     onClick = {
                         selectedItem?.let {
@@ -175,15 +163,7 @@ internal fun SelectPassportScreenContent(
 internal fun PreviewPassportSelectionScreen() {
     GdsTheme {
         SelectPassportScreenContent(
-            title = stringResource(R.string.selectdocument_passport_title),
-            readMoreButtonTitle = stringResource(R.string.selectdocument_passport_readmore_button),
             onReadMoreClick = { },
-            items =
-                listOf(
-                    R.string.selectdocument_passport_selection_yes,
-                    R.string.selectdocument_passport_selection_no,
-                ).map { stringResource(it) }.toPersistentList(),
-            confirmButtonText = stringResource(R.string.selectdocument_passport_continuebutton),
             onConfirmSelection = { },
         )
     }

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportState.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportState.kt
@@ -1,7 +1,0 @@
-package uk.gov.onelogin.criorchestrator.features.selectdoc.internal.passport
-
-import kotlinx.collections.immutable.PersistentList
-
-data class SelectPassportState(
-    val options: PersistentList<Int>,
-)

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportViewModel.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportViewModel.kt
@@ -2,31 +2,15 @@ package uk.gov.onelogin.criorchestrator.features.selectdoc.internal.passport
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import uk.gov.onelogin.criorchestrator.features.selectdoc.internal.R
 import uk.gov.onelogin.criorchestrator.features.selectdoc.internal.analytics.SelectDocumentAnalytics
 import uk.gov.onelogin.criorchestrator.features.selectdoc.internal.analytics.SelectDocumentScreenId
 
 internal class SelectPassportViewModel(
     private val analytics: SelectDocumentAnalytics,
 ) : ViewModel() {
-    private val _state =
-        MutableStateFlow(
-            SelectPassportState(
-                options =
-                    persistentListOf(
-                        R.string.selectdocument_passport_selection_yes,
-                        R.string.selectdocument_passport_selection_no,
-                    ),
-            ),
-        )
-    val state: StateFlow<SelectPassportState> = _state
-
     private val _actions = MutableSharedFlow<SelectPassportAction>()
     val actions: Flow<SelectPassportAction> = _actions
 
@@ -47,7 +31,7 @@ internal class SelectPassportViewModel(
     fun onConfirmSelection(selectedIndex: Int) {
         analytics.trackFormSubmission(
             buttonText = SelectPassportConstants.buttonTextId,
-            response = state.value.options[selectedIndex],
+            response = SelectPassportConstants.options[selectedIndex],
         )
 
         viewModelScope.launch {

--- a/features/select-doc/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportScreenAnalyticsTest.kt
+++ b/features/select-doc/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportScreenAnalyticsTest.kt
@@ -3,7 +3,6 @@ package uk.gov.onelogin.criorchestrator.features.selectdoc.internal.passport
 import android.content.Context
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onParent
 import androidx.compose.ui.test.performClick
@@ -12,6 +11,7 @@ import androidx.compose.ui.test.swipeUp
 import androidx.navigation.compose.rememberNavController
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -57,6 +57,16 @@ class SelectPassportScreenAnalyticsTest {
             analytics = analytics,
         )
 
+    @Before
+    fun setup() {
+        composeTestRule.setContent {
+            SelectPassportScreen(
+                viewModel = viewModel,
+                navController = rememberNavController(),
+            )
+        }
+    }
+
     @Test
     fun `when screen is started, it tracks analytics`() {
         val expectedEvent =
@@ -66,14 +76,11 @@ class SelectPassportScreenAnalyticsTest {
                     name = context.getString(R.string.selectdocument_passport_title),
                     params = SelectDocumentAnalytics.requiredParameters,
                 ).asLegacyEvent()
-        composeTestRule.setSelectPassportScreenContent()
         assertContains(analyticsLogger.loggedEvents, expectedEvent)
     }
 
     @Test
     fun `given selection is made, when continue button is clicked, it tracks analytics`() {
-        composeTestRule.setSelectPassportScreenContent()
-
         swipeToAdditionalContent()
 
         composeTestRule
@@ -96,8 +103,6 @@ class SelectPassportScreenAnalyticsTest {
 
     @Test
     fun `when read more is clicked, it tracks analytics`() {
-        composeTestRule.setSelectPassportScreenContent()
-
         swipeToAdditionalContent()
 
         composeTestRule
@@ -111,15 +116,6 @@ class SelectPassportScreenAnalyticsTest {
                     params = SelectDocumentAnalytics.requiredParameters,
                 ).asLegacyEvent()
         assertContains(analyticsLogger.loggedEvents, expectedEvent)
-    }
-
-    private fun ComposeContentTestRule.setSelectPassportScreenContent() {
-        setContent {
-            SelectPassportScreen(
-                viewModel = viewModel,
-                navController = rememberNavController(),
-            )
-        }
     }
 
     private fun swipeToAdditionalContent() {

--- a/features/select-doc/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportScreenTest.kt
+++ b/features/select-doc/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/SelectPassportScreenTest.kt
@@ -151,7 +151,7 @@ class SelectPassportScreenTest {
             .assertIsEnabled()
             .performClick()
 
-        verify(navController).navigate(SelectDocumentDestinations.Confirm)
+        verify(navController).navigate(SelectDocumentDestinations.ConfirmPassport)
     }
 
     @Test


### PR DESCRIPTION
# Refactor Select Passport to make is consistent with BRP

There are some inconsistencies and also applied the some changes based on feedback from https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/236

Changes:
- Rename confirm destination to `ConfirmPassport`
- Remove state from view model. This was being used for the yes/no list items but it was not storing the selected state in the view model. Changed it to be a constant just like the other text fields
- Remove static string parameters from `SelectPassportScreenContent` composable and referenced the `SelectPassportConstants` directly
- Replace the extension function with a `setup()` method on the `SelectPassportAnalyticsTest`


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
