### PR TITLE
refactor: Fix deprecated `FullScreenDialog`

### DIFF
--- a/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/modal/ProveYourIdentityModal.kt
+++ b/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/modal/ProveYourIdentityModal.kt
@@ -7,8 +7,8 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import kotlinx.collections.immutable.ImmutableSet
-import uk.gov.android.ui.patterns.dialog.FullScreenDialog
-import uk.gov.android.ui.patterns.dialog.FullScreenDialogTopAppBar
+import uk.gov.android.ui.patterns.dialog.FullScreenDialogue
+import uk.gov.android.ui.patterns.dialog.FullScreenDialogueTopAppBar
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.onelogin.criorchestrator.features.resume.internalapi.nav.ProveYourIdentityDestinations
 import uk.gov.onelogin.criorchestrator.features.resume.internalapi.nav.ProveYourIdentityNavGraphProvider
@@ -35,10 +35,10 @@ internal fun ProveYourIdentityModal(
         return
     }
 
-    FullScreenDialog(
+    FullScreenDialogue(
         modifier = modifier,
         topAppBar = {
-            FullScreenDialogTopAppBar(
+            FullScreenDialogueTopAppBar(
                 onCloseClick = {
                     onCancelClick()
                     state.onDismissRequest()

--- a/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/devmenu/DevMenuDialog.kt
+++ b/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/devmenu/DevMenuDialog.kt
@@ -3,7 +3,7 @@ package uk.gov.onelogin.criorchestrator.testwrapper.devmenu
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import uk.gov.android.ui.patterns.dialog.FullScreenDialog
+import uk.gov.android.ui.patterns.dialog.FullScreenDialogue
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.onelogin.criorchestrator.features.dev.publicapi.DevMenuScreen
 import uk.gov.onelogin.criorchestrator.sdk.sharedapi.CriOrchestratorComponent
@@ -16,7 +16,7 @@ internal fun DevMenuDialog(
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    FullScreenDialog(
+    FullScreenDialogue(
         modifier = modifier,
         onDismissRequest = onDismissRequest,
     ) {


### PR DESCRIPTION
## Context

- https://github.com/govuk-one-login/mobile-android-cri-orchestrator/runs/39908953212


## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
