### PR TITLE
fix: resolve issue with selected option in Select Driving Licence screen

### DIFF
--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/drivinglicence/SelectDrivingLicenceScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/drivinglicence/SelectDrivingLicenceScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -88,7 +88,7 @@ internal fun SelectDrivingLicenceScreenContent(
     displayReadMoreButton: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    var selectedItem by remember { mutableStateOf<Int?>(null) }
+    var selectedItem by rememberSaveable { mutableStateOf<Int?>(null) }
 
     Surface(
         modifier = modifier,


### PR DESCRIPTION
DCMAW-8099: resolve issue with selected option in Select Driving Licence screen

- Replace `remember` with `rememberSaveable` to ensure an option remains selected when a user clicks the confirm button and then the back button to return to the Select Driving Licence Screen. 

## Evidence of the change
**English NFC Enabled**
[Light Mode](https://github.com/user-attachments/assets/beab4604-ca24-400b-b619-25465f380e74)
[Dark Mode](https://github.com/user-attachments/assets/1b8fba67-ad5c-43af-895f-a3294de75607)

**English NFC Not Enabled**
[Light Mode](https://github.com/user-attachments/assets/781cf014-df94-45bb-bdaf-4f14762a6777)
[Dark Mode](https://github.com/user-attachments/assets/8a987736-3924-4626-b4cd-4afde1f0e248)

**Welsh NFC Enabled**
[Light Mode](https://github.com/user-attachments/assets/8ac347b5-8212-4735-a9f2-56de6c3454b2)
[Dark Mode](https://github.com/user-attachments/assets/2dd18f0b-1c07-4346-801b-b66d31b77259)

**Welsh NFC Not Enabled**
[Light Mode](https://github.com/user-attachments/assets/b76066af-7e14-4cb1-8b03-b93ede019a44)
[Dark Mode](https://github.com/user-attachments/assets/e82ea6b5-2e65-4703-a3d7-beee6bba3015)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
