### PR TITLE
feat: Allow dev settings switches to be toggled by clicking labels

### DIFF
--- a/features/dev/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/dev/internal/screen/ui/ConfigEntry.kt
+++ b/features/dev/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/dev/internal/screen/ui/ConfigEntry.kt
@@ -1,16 +1,21 @@
 package uk.gov.onelogin.criorchestrator.features.dev.internal.screen.ui
 
-import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import uk.gov.android.ui.theme.m3.GdsTheme
@@ -56,14 +61,30 @@ private fun ConfigBoolEntry(
     value: Boolean,
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
-) = ConfigEntryLayout(
-    name = name,
-    modifier = modifier,
+) = Surface(
+    color = MaterialTheme.colorScheme.background,
 ) {
-    Switch(
-        checked = value,
-        onCheckedChange = onCheckedChange,
-    )
+    Row(
+        modifier =
+            modifier
+                .clickable(
+                    role = Role.Switch,
+                    onClick = { onCheckedChange(!value) },
+                ).fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            color = MaterialTheme.colorScheme.onBackground,
+            style = MaterialTheme.typography.titleMedium,
+            text = name,
+        )
+        Switch(
+            checked = value,
+            onCheckedChange = onCheckedChange,
+        )
+    }
 }
 
 @Composable
@@ -72,36 +93,24 @@ private fun ConfigStrEntry(
     value: String,
     onValueChanged: (String) -> Unit,
     modifier: Modifier = Modifier,
-) = ConfigEntryLayout(
-    name = name,
-    modifier = modifier,
-) {
-    TextField(
-        shape = RectangleShape,
-        value = value,
-        onValueChange = onValueChanged,
-    )
-}
-
-@Composable
-private fun ConfigEntryLayout(
-    name: String,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
+) = Surface(
+    color = MaterialTheme.colorScheme.background,
+    modifier = modifier.padding(horizontal = 16.dp),
 ) {
     Column(
-        modifier =
-            modifier
-                .background(
-                    color = MaterialTheme.colorScheme.background,
-                ).padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Text(
-            color = MaterialTheme.colorScheme.onBackground,
-            style = MaterialTheme.typography.titleMedium,
             text = name,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onBackground,
         )
-        content()
+        TextField(
+            shape = RectangleShape,
+            value = value,
+            onValueChange = onValueChanged,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }
 

--- a/features/dev/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/dev/internal/screen/ui/ConfigEntryTest.kt
+++ b/features/dev/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/dev/internal/screen/ui/ConfigEntryTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.criorchestrator.features.dev.internal.screen.ui
 
-import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -62,7 +61,7 @@ class ConfigEntryTest {
             }
 
         composeTestRule
-            .onNode(hasClickAction())
+            .onNodeWithText(stubBooleanConfigEntry().key.name)
             .performClick()
 
         verify(onEntryChange).invoke(

--- a/features/dev/internal/src/test/snapshots/images/features.dev.internal.screen.ui_ConfigEntryKt_ConfigEntryPreview_Dark_NIGHT.png
+++ b/features/dev/internal/src/test/snapshots/images/features.dev.internal.screen.ui_ConfigEntryKt_ConfigEntryPreview_Dark_NIGHT.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff3fafbc8e54dabcad2c7ea92ae8f68f74db4a6caa9dcc1fd1a4b539bad27a9e
-size 13334
+oid sha256:214d855cea430a925f599bdfe8623aa82fd168c53e17025b2b5329bcf182bc89
+size 13358

--- a/features/dev/internal/src/test/snapshots/images/features.dev.internal.screen.ui_ConfigEntryKt_ConfigEntryPreview_Light.png
+++ b/features/dev/internal/src/test/snapshots/images/features.dev.internal.screen.ui_ConfigEntryKt_ConfigEntryPreview_Light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5390f92a710156d5c5f34e54a2012b6765c79beefb6360fd0b44e117c3528330
-size 13640
+oid sha256:a93b2aeede23f363adbbf8c4ed42d62fd4c6c3d21d812435406fd9da4d5ebc85
+size 13586

--- a/features/dev/internal/src/test/snapshots/images/features.dev.internal.screen.ui_DevMenuKt_DevMenuPreview_Dark_NIGHT.png
+++ b/features/dev/internal/src/test/snapshots/images/features.dev.internal.screen.ui_DevMenuKt_DevMenuPreview_Dark_NIGHT.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3ee55c335f1470eb9f499dd74150a570aacc62bb56533af68b0567a38e48968
-size 16512
+oid sha256:12d818e520b342c622cb4217c8e7401d480f5d24f76d5b06da99cd2eeb759c8e
+size 16479

--- a/features/dev/internal/src/test/snapshots/images/features.dev.internal.screen.ui_DevMenuKt_DevMenuPreview_Light.png
+++ b/features/dev/internal/src/test/snapshots/images/features.dev.internal.screen.ui_DevMenuKt_DevMenuPreview_Light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6f8b6b99067958d48efca11b2c4e83445a0ba2ae473fdcb4a34beea1241b718
-size 16838
+oid sha256:c5ad2386917448a5ce0ebbcd4f49fab502549ff6f50c046214b9cd7dcb5e7878
+size 16755


### PR DESCRIPTION
## Changes

- Allow dev settings switches to be toggled by clicking labels.
- Refactor and improve layout of developer settings.

## Context

DCMAW-12575

This enables automated testing; in UI tests where we need to toggle configuration, this makes it simple to do.

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
