### PR TITLE
test: Replace dispatchers with test dispatcher in UI tests

### DIFF
--- a/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/extensions/Dependencies.kt
+++ b/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/extensions/Dependencies.kt
@@ -78,8 +78,12 @@ internal fun DependencyHandlerScope.uiDependencies(libs: LibrariesForLibs) = lis
 }
 
 internal fun DependencyHandlerScope.testDependencies(libs: LibrariesForLibs) {
+    testFixturesImplementation(libs.kotlinx.coroutines)
+    testFixturesImplementation(libs.kotlinx.coroutines.test)
+
     testImplementation(kotlin("test"))
     testImplementation(libs.app.cash.turbine)
+    testImplementation(libs.kotlinx.coroutines)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.org.junit.jupiter.api)
     testImplementation(libs.org.junit.jupiter.engine)

--- a/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/BaseCriOrchestratorSingletonComponent.kt
+++ b/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/BaseCriOrchestratorSingletonComponent.kt
@@ -3,11 +3,14 @@ package uk.gov.onelogin.criorchestrator.sdk.internal
 import android.content.Context
 import com.squareup.anvil.annotations.MergeComponent
 import dagger.BindsInstance
+import kotlinx.coroutines.CoroutineDispatcher
 import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.logging.api.Logger
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorSingletonScope
+import uk.gov.onelogin.criorchestrator.sdk.internal.di.CoroutineDispatchersModule.Companion.TEST_DISPATCHER_NAME
+import javax.inject.Named
 import javax.inject.Singleton
 
 /**
@@ -18,12 +21,14 @@ import javax.inject.Singleton
 interface BaseCriOrchestratorSingletonComponent {
     @MergeComponent.Factory
     interface Factory {
+        @Suppress("LongParameterList")
         fun create(
             @BindsInstance authenticatedHttpClient: GenericHttpClient,
             @BindsInstance analyticsLogger: AnalyticsLogger,
             @BindsInstance initialConfig: Config,
             @BindsInstance logger: Logger,
             @BindsInstance applicationContext: Context,
+            @BindsInstance @Named(TEST_DISPATCHER_NAME) testDispatcher: CoroutineDispatcher?,
         ): BaseCriOrchestratorSingletonComponent
     }
 

--- a/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/CriOrchestratorSingletonImpl.kt
+++ b/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/CriOrchestratorSingletonImpl.kt
@@ -1,6 +1,7 @@
 package uk.gov.onelogin.criorchestrator.sdk.internal
 
 import android.content.Context
+import kotlinx.coroutines.CoroutineDispatcher
 import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.logging.api.Logger
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
@@ -15,6 +16,8 @@ import uk.gov.onelogin.criorchestrator.sdk.sharedapi.CriOrchestratorSingletonCom
  *   Configuration may be updated through the developer menu.
  * @param logger The logger that logs events to the system and to Crashlytics.
  * @param applicationContext The host application
+ * @param testDispatcher Coroutine dispatcher to use in place of
+ *   IO, Default and Unconfined dispatchers.
  */
 class CriOrchestratorSingletonImpl(
     authenticatedHttpClient: GenericHttpClient,
@@ -22,6 +25,7 @@ class CriOrchestratorSingletonImpl(
     initialConfig: Config,
     logger: Logger,
     applicationContext: Context,
+    testDispatcher: CoroutineDispatcher? = null,
 ) : CriOrchestratorSdk {
     override val component: CriOrchestratorSingletonComponent =
         DaggerMergedBaseCriOrchestratorSingletonComponent.factory().create(
@@ -30,5 +34,6 @@ class CriOrchestratorSingletonImpl(
             initialConfig = initialConfig,
             logger = logger,
             applicationContext = applicationContext,
+            testDispatcher = testDispatcher,
         )
 }

--- a/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/di/CoroutineDispatchersModule.kt
+++ b/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/di/CoroutineDispatchersModule.kt
@@ -3,12 +3,33 @@ package uk.gov.onelogin.criorchestrator.sdk.internal.di
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
-import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorSingletonScope
 import uk.gov.onelogin.criorchestrator.libraries.kotlinutils.CoroutineDispatchers
+import javax.inject.Named
 
 @Module
-@ContributesTo(CriOrchestratorScope::class)
+@ContributesTo(CriOrchestratorSingletonScope::class)
 class CoroutineDispatchersModule {
     @Provides
-    fun provideCoroutineDispatchers() = CoroutineDispatchers()
+    fun provideCoroutineDispatchers(
+        @Named(TEST_DISPATCHER_NAME)
+        testDispatcher: CoroutineDispatcher?,
+    ): CoroutineDispatchers {
+        if (testDispatcher != null) {
+            return CoroutineDispatchers(
+                default = testDispatcher,
+                io = testDispatcher,
+                main = Dispatchers.Main,
+                unconfined = testDispatcher,
+            )
+        }
+
+        return CoroutineDispatchers()
+    }
+
+    companion object {
+        const val TEST_DISPATCHER_NAME = "testDispatcher"
+    }
 }

--- a/sdk/public-api/build.gradle.kts
+++ b/sdk/public-api/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     testFixturesImplementation(libs.org.mockito.kotlin)
     testFixturesImplementation(libs.uk.gov.logging.api)
     testFixturesImplementation(libs.uk.gov.networking)
+    testFixturesImplementation(projects.sdk.internal)
 
     testImplementation(libs.uk.gov.logging.testdouble)
     testImplementation(projects.features.config.publicApi)

--- a/sdk/public-api/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/sdk/publicapi/CriOrchestratorSdkTestExt.kt
+++ b/sdk/public-api/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/sdk/publicapi/CriOrchestratorSdkTestExt.kt
@@ -1,6 +1,9 @@
 package uk.gov.onelogin.criorchestrator.sdk.publicapi
 
 import android.content.Context
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.mockito.Mockito.mock
 import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.client.GenericHttpClient
@@ -8,9 +11,11 @@ import uk.gov.android.network.client.StubHttpClient
 import uk.gov.logging.api.Logger
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
-import uk.gov.onelogin.criorchestrator.sdk.publicapi.CriOrchestratorSdkExt.create
+import uk.gov.onelogin.criorchestrator.sdk.internal.CriOrchestratorSingletonImpl
 import uk.gov.onelogin.criorchestrator.sdk.sharedapi.CriOrchestratorSdk
 
+@OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("LongParameterList")
 fun CriOrchestratorSdk.Companion.createTestInstance(
     authenticatedHttpClient: GenericHttpClient =
         StubHttpClient(
@@ -20,11 +25,13 @@ fun CriOrchestratorSdk.Companion.createTestInstance(
     initialConfig: Config = Config.createTestInstance(),
     logger: Logger = mock(),
     applicationContext: Context = mock(),
+    testDispatcher: CoroutineDispatcher? = UnconfinedTestDispatcher(),
 ): CriOrchestratorSdk =
-    this.create(
+    CriOrchestratorSingletonImpl(
         authenticatedHttpClient = authenticatedHttpClient,
         analyticsLogger = analyticsLogger,
         initialConfig = initialConfig,
         logger = logger,
         applicationContext = applicationContext,
+        testDispatcher = testDispatcher,
     )


### PR DESCRIPTION
## Changes

Enable tests to inject a coroutine dispatcher to replace the IO, Default and Unconfined dispatchers.

## Context

Enables UI tests that depend on asynchronous work done off the Main dispatcher. When replaced with a test dispatcher, coroutines are run eagerly and the screen doesn't appear idle while work is done.

## Evidence of the change

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
