### PR TITLE
refactor: Simplify session reader from `Flow` to `suspend` function

### DIFF
--- a/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/extensions/Dependencies.kt
+++ b/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/extensions/Dependencies.kt
@@ -80,6 +80,7 @@ internal fun DependencyHandlerScope.uiDependencies(libs: LibrariesForLibs) = lis
 internal fun DependencyHandlerScope.testDependencies(libs: LibrariesForLibs) {
     testFixturesImplementation(libs.kotlinx.coroutines)
     testFixturesImplementation(libs.kotlinx.coroutines.test)
+    testFixturesImplementation(libs.org.mockito.kotlin)
 
     testImplementation(kotlin("test"))
     testImplementation(libs.app.cash.turbine)

--- a/features/resume/internal/build.gradle.kts
+++ b/features/resume/internal/build.gradle.kts
@@ -19,8 +19,9 @@ dependencies {
     implementation(projects.libraries.di)
     implementation(projects.libraries.navigation)
 
-    testImplementation(testFixtures(projects.libraries.analytics))
+    testFixturesImplementation(testFixtures(projects.features.session.internalApi))
 
+    testImplementation(testFixtures(projects.libraries.analytics))
     testImplementation(libs.uk.gov.logging.testdouble)
     testImplementation(testFixtures(projects.features.session.internalApi))
     testImplementation(kotlin("test"))

--- a/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityRootUiState.kt
+++ b/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityRootUiState.kt
@@ -1,5 +1,5 @@
 package uk.gov.onelogin.criorchestrator.features.resume.internal.root
 
-internal data class ProveYourIdentityRootUiState(
+data class ProveYourIdentityRootUiState(
     val shouldDisplay: Boolean,
 )

--- a/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityViewModelModule.kt
+++ b/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityViewModelModule.kt
@@ -1,12 +1,12 @@
 package uk.gov.onelogin.criorchestrator.features.resume.internal.root
 
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
-import uk.gov.logging.api.Logger
 import uk.gov.onelogin.criorchestrator.features.resume.internal.analytics.ResumeAnalytics
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionReader
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
@@ -22,14 +22,13 @@ object ProveYourIdentityViewModelModule {
     fun provideFactory(
         resumeAnalytics: ResumeAnalytics,
         sessionReader: SessionReader,
-        logger: Logger,
     ): ViewModelProvider.Factory =
         viewModelFactory {
             initializer {
                 ProveYourIdentityViewModel(
                     analytics = resumeAnalytics,
                     sessionReader = sessionReader,
-                    logger = logger,
+                    savedStateHandle = createSavedStateHandle(),
                 )
             }
         }

--- a/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/ProveYourIdentityEntryPointsImplTest.kt
+++ b/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/ProveYourIdentityEntryPointsImplTest.kt
@@ -13,12 +13,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import uk.gov.android.ui.theme.m3.GdsTheme
-import uk.gov.logging.testdouble.SystemLogger
-import uk.gov.onelogin.criorchestrator.features.resume.internal.analytics.ResumeAnalytics
 import uk.gov.onelogin.criorchestrator.features.resume.internal.root.ProveYourIdentityViewModel
+import uk.gov.onelogin.criorchestrator.features.resume.internal.root.createTestInstance
 import uk.gov.onelogin.criorchestrator.features.resume.internal.screen.ContinueToProveYourIdentityNavGraphProvider
 import uk.gov.onelogin.criorchestrator.features.resume.internal.screen.ContinueToProveYourIdentityViewModelModule
-import uk.gov.onelogin.criorchestrator.features.session.internalapi.StubSessionReader
 
 @RunWith(AndroidJUnit4::class)
 class ProveYourIdentityEntryPointsImplTest {
@@ -26,11 +24,7 @@ class ProveYourIdentityEntryPointsImplTest {
     val composeTestRule = createComposeRule()
 
     private val fakeProveYourIdentityViewModel =
-        ProveYourIdentityViewModel(
-            analytics = mock<ResumeAnalytics>(),
-            sessionReader = StubSessionReader(),
-            logger = SystemLogger(),
-        )
+        ProveYourIdentityViewModel.createTestInstance()
 
     private val fakeViewModelProviderFactory =
         viewModelFactory {

--- a/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityCardAnalyticsTest.kt
+++ b/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityCardAnalyticsTest.kt
@@ -18,12 +18,10 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import uk.gov.logging.api.v3dot1.logger.asLegacyEvent
 import uk.gov.logging.api.v3dot1.model.TrackEvent
-import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.criorchestrator.features.resume.internal.R
 import uk.gov.onelogin.criorchestrator.features.resume.internal.analytics.ResumeAnalytics
 import uk.gov.onelogin.criorchestrator.features.resume.internal.screen.ContinueToProveYourIdentityNavGraphProvider
 import uk.gov.onelogin.criorchestrator.features.resume.internal.screen.ContinueToProveYourIdentityViewModelModule
-import uk.gov.onelogin.criorchestrator.features.session.internalapi.StubSessionReader
 import uk.gov.onelogin.criorchestrator.libraries.analytics.resources.AndroidResourceProvider
 import uk.gov.onelogin.criorchestrator.libraries.testing.ReportingAnalyticsLoggerRule
 import kotlin.test.assertContains
@@ -39,14 +37,12 @@ class ProveYourIdentityCardAnalyticsTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val viewModel =
-        ProveYourIdentityViewModel(
+        ProveYourIdentityViewModel.createTestInstance(
             analytics =
                 ResumeAnalytics(
                     resourceProvider = AndroidResourceProvider(context),
                     analyticsLogger = analyticsLogger,
                 ),
-            sessionReader = StubSessionReader(),
-            logger = SystemLogger(),
         )
 
     private val modal: SemanticsMatcher = hasTestTag(ProveYourIdentityRootTestTags.MODAL)

--- a/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityModalAnalyticsTest.kt
+++ b/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityModalAnalyticsTest.kt
@@ -14,12 +14,10 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import uk.gov.logging.api.v3dot1.logger.asLegacyEvent
 import uk.gov.logging.api.v3dot1.model.TrackEvent
-import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.criorchestrator.features.resume.internal.R
 import uk.gov.onelogin.criorchestrator.features.resume.internal.analytics.ResumeAnalytics
 import uk.gov.onelogin.criorchestrator.features.resume.internal.screen.ContinueToProveYourIdentityNavGraphProvider
 import uk.gov.onelogin.criorchestrator.features.resume.internal.screen.ContinueToProveYourIdentityViewModelModule
-import uk.gov.onelogin.criorchestrator.features.session.internalapi.StubSessionReader
 import uk.gov.onelogin.criorchestrator.libraries.analytics.resources.AndroidResourceProvider
 import uk.gov.onelogin.criorchestrator.libraries.testing.ReportingAnalyticsLoggerRule
 import kotlin.test.assertContains
@@ -35,14 +33,12 @@ class ProveYourIdentityModalAnalyticsTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val viewModel =
-        ProveYourIdentityViewModel(
+        ProveYourIdentityViewModel.createTestInstance(
             analytics =
                 ResumeAnalytics(
                     resourceProvider = AndroidResourceProvider(context),
                     analyticsLogger = analyticsLogger,
                 ),
-            sessionReader = StubSessionReader(),
-            logger = SystemLogger(),
         )
 
     // FIXME This content description should be "Cancel button"

--- a/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityRootTest.kt
+++ b/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityRootTest.kt
@@ -20,12 +20,9 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.kotlin.verify
-import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.criorchestrator.features.resume.internal.R
-import uk.gov.onelogin.criorchestrator.features.resume.internal.analytics.ResumeAnalytics
 import uk.gov.onelogin.criorchestrator.features.resume.internal.screen.ContinueToProveYourIdentityNavGraphProvider
 import uk.gov.onelogin.criorchestrator.features.resume.internal.screen.ContinueToProveYourIdentityViewModelModule
-import uk.gov.onelogin.criorchestrator.features.session.internalapi.StubSessionReader
 
 @RunWith(AndroidJUnit4::class)
 class ProveYourIdentityRootTest {
@@ -35,11 +32,7 @@ class ProveYourIdentityRootTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val viewModel =
         spy(
-            ProveYourIdentityViewModel(
-                analytics = mock<ResumeAnalytics>(),
-                sessionReader = StubSessionReader(),
-                logger = SystemLogger(),
-            ),
+            ProveYourIdentityViewModel.createTestInstance(),
         )
 
     private val card: SemanticsMatcher = hasTestTag(ProveYourIdentityRootTestTags.CARD)

--- a/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityViewModelTest.kt
+++ b/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityViewModelTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.onelogin.criorchestrator.features.resume.internal.root
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -14,9 +15,7 @@ import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
 import uk.gov.logging.api.v3dot1.model.AnalyticsEvent
 import uk.gov.logging.api.v3dot1.model.RequiredParameters
 import uk.gov.logging.api.v3dot1.model.TrackEvent
-import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.criorchestrator.features.resume.internal.analytics.ResumeAnalytics
-import uk.gov.onelogin.criorchestrator.features.session.internalapi.StubSessionReader
 import uk.gov.onelogin.criorchestrator.libraries.analytics.resources.FakeResourceProvider
 import uk.gov.onelogin.criorchestrator.libraries.testing.MainDispatcherExtension
 
@@ -24,15 +23,15 @@ import uk.gov.onelogin.criorchestrator.libraries.testing.MainDispatcherExtension
 class ProveYourIdentityViewModelTest {
     private val analyticsLogger = mock<AnalyticsLogger>()
     private val resourceProvider = FakeResourceProvider()
+    private var savedStateHandle = SavedStateHandle(emptyMap())
     private val viewModel by lazy {
-        ProveYourIdentityViewModel(
+        ProveYourIdentityViewModel.createTestInstance(
             analytics =
                 ResumeAnalytics(
                     resourceProvider = resourceProvider,
                     analyticsLogger = analyticsLogger,
                 ),
-            sessionReader = StubSessionReader(),
-            logger = SystemLogger(),
+            savedStateHandle = savedStateHandle,
         )
     }
 
@@ -48,6 +47,21 @@ class ProveYourIdentityViewModelTest {
         runTest {
             viewModel.state.test {
                 assertEquals(INITIAL_STATE, awaitItem())
+            }
+        }
+
+    @Test
+    fun `given saved state, initial state is restored`() =
+        runTest {
+            savedStateHandle =
+                SavedStateHandle(
+                    mapOf(
+                        ProveYourIdentityViewModel.SHOULD_DISPLAY_KEY to true,
+                    ),
+                )
+            val expected = INITIAL_STATE.copy(shouldDisplay = true)
+            viewModel.state.test {
+                assertEquals(expected, awaitItem())
             }
         }
 

--- a/features/resume/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityViewModelExt.kt
+++ b/features/resume/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityViewModelExt.kt
@@ -1,0 +1,17 @@
+package uk.gov.onelogin.criorchestrator.features.resume.internal.root
+
+import androidx.lifecycle.SavedStateHandle
+import org.mockito.Mockito.mock
+import uk.gov.onelogin.criorchestrator.features.resume.internal.analytics.ResumeAnalytics
+import uk.gov.onelogin.criorchestrator.features.session.internalapi.StubSessionReader
+import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionReader
+
+fun ProveYourIdentityViewModel.Companion.createTestInstance(
+    sessionReader: SessionReader = StubSessionReader(),
+    analytics: ResumeAnalytics = mock(),
+    savedStateHandle: SavedStateHandle = SavedStateHandle(),
+) = ProveYourIdentityViewModel(
+    analytics = analytics,
+    sessionReader = sessionReader,
+    savedStateHandle = savedStateHandle,
+)

--- a/features/session/internal-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internalapi/domain/SessionReader.kt
+++ b/features/session/internal-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internalapi/domain/SessionReader.kt
@@ -1,7 +1,5 @@
 package uk.gov.onelogin.criorchestrator.features.session.internalapi.domain
 
-import kotlinx.coroutines.flow.Flow
-
 fun interface SessionReader {
-    fun isActiveSession(): Flow<Boolean>
+    suspend fun isActiveSession(): Boolean
 }

--- a/features/session/internal-api/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/session/internalapi/StubSessionReader.kt
+++ b/features/session/internal-api/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/session/internalapi/StubSessionReader.kt
@@ -1,11 +1,9 @@
 package uk.gov.onelogin.criorchestrator.features.session.internalapi
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionReader
 
 class StubSessionReader(
     private val isActiveSession: Boolean = true,
 ) : SessionReader {
-    override fun isActiveSession(): Flow<Boolean> = flowOf(isActiveSession)
+    override suspend fun isActiveSession(): Boolean = isActiveSession
 }


### PR DESCRIPTION
## Change

Simplify `SessionReader.isActiveSession()` from `Flow` to `suspend` function.

## Context
DCMAW-12575

We made the `RemoteSessionReader` reactive to changes in config to accommodate the test wrapper setup where config could be changed after launching the journey.

This now causes problems as, in order to continue smoothly after process death, we need to resubscribe to the Flow and hence retrigger the API calls. If the API call fails, we clear the session from the store, which is not what we want.

With the new test wrapper setup this reactive session reader is no longer needed.

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [x] Check against acceptance criteria
- [x] Add automated tests
- [x] Self-review code
