### PR TITLE
refactor: Rename `@ActivityScope` to `@CompositionScope`

### DIFF
--- a/features/dev/internal-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/dev/internalapi/DevMenuEntryPoints.kt
+++ b/features/dev/internal-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/dev/internalapi/DevMenuEntryPoints.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
 import com.squareup.anvil.annotations.ContributesTo
-import uk.gov.onelogin.criorchestrator.libraries.di.ActivityScope
+import uk.gov.onelogin.criorchestrator.libraries.di.CompositionScope
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 
 @Immutable
@@ -13,7 +13,7 @@ fun interface DevMenuEntryPoints {
     fun DevMenuScreen(modifier: Modifier)
 }
 
-@ActivityScope
+@CompositionScope
 @ContributesTo(CriOrchestratorScope::class)
 fun interface DevMenuEntryPointsComponent {
     fun devMenuEntryPoints(): DevMenuEntryPoints

--- a/features/dev/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/dev/internal/DevMenuComponent.kt
+++ b/features/dev/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/dev/internal/DevMenuComponent.kt
@@ -3,11 +3,11 @@ package uk.gov.onelogin.criorchestrator.features.dev.internal
 import androidx.lifecycle.ViewModelProvider
 import com.squareup.anvil.annotations.ContributesTo
 import uk.gov.onelogin.criorchestrator.features.dev.internal.screen.DevMenuViewModelModule
-import uk.gov.onelogin.criorchestrator.libraries.di.ActivityScope
+import uk.gov.onelogin.criorchestrator.libraries.di.CompositionScope
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 import javax.inject.Named
 
-@ActivityScope
+@CompositionScope
 @ContributesTo(CriOrchestratorScope::class)
 interface DevMenuComponent {
     @Named(DevMenuViewModelModule.FACTORY_NAME)

--- a/features/dev/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/dev/internal/DevMenuEntryPointsImpl.kt
+++ b/features/dev/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/dev/internal/DevMenuEntryPointsImpl.kt
@@ -9,12 +9,12 @@ import com.squareup.anvil.annotations.ContributesBinding
 import uk.gov.onelogin.criorchestrator.features.dev.internal.screen.DevMenuScreen
 import uk.gov.onelogin.criorchestrator.features.dev.internal.screen.DevMenuViewModelModule
 import uk.gov.onelogin.criorchestrator.features.dev.internalapi.DevMenuEntryPoints
-import uk.gov.onelogin.criorchestrator.libraries.di.ActivityScope
+import uk.gov.onelogin.criorchestrator.libraries.di.CompositionScope
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 import javax.inject.Inject
 import javax.inject.Named
 
-@ActivityScope
+@CompositionScope
 @ContributesBinding(CriOrchestratorScope::class)
 class DevMenuEntryPointsImpl
     @Inject

--- a/features/resume/internal-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internalapi/ProveYourIdentityEntryPoints.kt
+++ b/features/resume/internal-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internalapi/ProveYourIdentityEntryPoints.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
 import com.squareup.anvil.annotations.ContributesTo
-import uk.gov.onelogin.criorchestrator.libraries.di.ActivityScope
+import uk.gov.onelogin.criorchestrator.libraries.di.CompositionScope
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 
 @Immutable
@@ -13,7 +13,7 @@ fun interface ProveYourIdentityEntryPoints {
     fun ProveYourIdentityCard(modifier: Modifier)
 }
 
-@ActivityScope
+@CompositionScope
 @ContributesTo(CriOrchestratorScope::class)
 fun interface ProveYourIdentityEntryPointsComponent {
     fun proveYourIdentityEntryPoints(): ProveYourIdentityEntryPoints

--- a/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/ProveYourIdentityComponent.kt
+++ b/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/ProveYourIdentityComponent.kt
@@ -3,11 +3,11 @@ package uk.gov.onelogin.criorchestrator.features.resume.internal
 import androidx.lifecycle.ViewModelProvider
 import com.squareup.anvil.annotations.ContributesTo
 import uk.gov.onelogin.criorchestrator.features.resume.internal.root.ProveYourIdentityViewModelModule
-import uk.gov.onelogin.criorchestrator.libraries.di.ActivityScope
+import uk.gov.onelogin.criorchestrator.libraries.di.CompositionScope
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 import javax.inject.Named
 
-@ActivityScope
+@CompositionScope
 @ContributesTo(CriOrchestratorScope::class)
 interface ProveYourIdentityComponent {
     @Named(ProveYourIdentityViewModelModule.FACTORY_NAME)

--- a/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/ProveYourIdentityEntryPointsImpl.kt
+++ b/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/ProveYourIdentityEntryPointsImpl.kt
@@ -11,12 +11,12 @@ import uk.gov.onelogin.criorchestrator.features.resume.internal.root.ProveYourId
 import uk.gov.onelogin.criorchestrator.features.resume.internal.root.ProveYourIdentityViewModelModule
 import uk.gov.onelogin.criorchestrator.features.resume.internalapi.ProveYourIdentityEntryPoints
 import uk.gov.onelogin.criorchestrator.features.resume.internalapi.nav.ProveYourIdentityNavGraphProvider
-import uk.gov.onelogin.criorchestrator.libraries.di.ActivityScope
+import uk.gov.onelogin.criorchestrator.libraries.di.CompositionScope
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 import javax.inject.Inject
 import javax.inject.Named
 
-@ActivityScope
+@CompositionScope
 @ContributesBinding(CriOrchestratorScope::class)
 class ProveYourIdentityEntryPointsImpl
     @Inject

--- a/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/nfc/NfcModule.kt
+++ b/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/nfc/NfcModule.kt
@@ -7,17 +7,17 @@ import dagger.Module
 import dagger.Provides
 import uk.gov.idcheck.sdk.passport.nfc.checker.NfcChecker
 import uk.gov.idcheck.sdk.passport.nfc.checker.NfcCheckerImpl
-import uk.gov.onelogin.criorchestrator.libraries.di.ActivityScope
+import uk.gov.onelogin.criorchestrator.libraries.di.CompositionScope
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 
 @Module
 @ContributesTo(CriOrchestratorScope::class)
 object NfcModule {
     @Provides
-    @ActivityScope
+    @CompositionScope
     fun providesNfcManager(context: Context): NfcManager = context.getSystemService(Context.NFC_SERVICE) as NfcManager
 
     @Provides
-    @ActivityScope
+    @CompositionScope
     fun provideNfcChecker(nfcManager: NfcManager): NfcChecker = NfcCheckerImpl(nfcManager)
 }

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/RemoteSessionReader.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/RemoteSessionReader.kt
@@ -10,12 +10,12 @@ import uk.gov.onelogin.criorchestrator.features.session.internal.network.respons
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.Session
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionReader
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionStore
-import uk.gov.onelogin.criorchestrator.libraries.di.ActivityScope
+import uk.gov.onelogin.criorchestrator.libraries.di.CompositionScope
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ActivityScope
+@CompositionScope
 @ContributesBinding(CriOrchestratorScope::class, boundType = SessionReader::class)
 class RemoteSessionReader
     @Inject

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/SessionApiImpl.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/SessionApiImpl.kt
@@ -7,12 +7,12 @@ import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.logging.api.LogTagProvider
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey.IdCheckAsyncBackendBaseUrl
-import uk.gov.onelogin.criorchestrator.libraries.di.ActivityScope
+import uk.gov.onelogin.criorchestrator.libraries.di.CompositionScope
 import javax.inject.Inject
 
 private const val GET_ACTIVE_SESSION_ENDPOINT = "/async/activeSession"
 
-@ActivityScope
+@CompositionScope
 class SessionApiImpl
     @Inject
     constructor(

--- a/libraries/di/src/main/kotlin/uk/gov/onelogin/criorchestrator/libraries/di/CompositionScope.kt
+++ b/libraries/di/src/main/kotlin/uk/gov/onelogin/criorchestrator/libraries/di/CompositionScope.kt
@@ -3,9 +3,9 @@ package uk.gov.onelogin.criorchestrator.libraries.di
 import javax.inject.Scope
 
 /**
- * Dagger scope intended for use at Activity level.
+ * Dagger scope for objects that live no longer than the Compose UI composition.
  */
 @Scope
 @MustBeDocumented
 @Retention(AnnotationRetention.RUNTIME)
-annotation class ActivityScope
+annotation class CompositionScope

--- a/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/BaseCriOrchestratorComponent.kt
+++ b/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/BaseCriOrchestratorComponent.kt
@@ -5,13 +5,13 @@ import com.squareup.anvil.annotations.MergeComponent
 import dagger.BindsInstance
 import uk.gov.onelogin.criorchestrator.features.config.internal.ConfigComponent
 import uk.gov.onelogin.criorchestrator.features.session.internal.SessionComponent
-import uk.gov.onelogin.criorchestrator.libraries.di.ActivityScope
+import uk.gov.onelogin.criorchestrator.libraries.di.CompositionScope
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 
 /**
  * The real Dagger component that other component interfaces and modules will be merged into.
  */
-@ActivityScope
+@CompositionScope
 @MergeComponent(
     CriOrchestratorScope::class,
     dependencies = [


### PR DESCRIPTION
## Changes

Rename `@ActivityScope` to `@CompositionScope`.

## Context

DCMAW-12575

Helps convey that components/objects with this scope will not outlive the composition, let alone the Activity being recreated.

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
