### PR TITLE
fix: bump UI library version to 7.18.1

### DIFF
--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/brp/confirm/ConfirmBrpScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/brp/confirm/ConfirmBrpScreen.kt
@@ -19,6 +19,7 @@ import androidx.navigation.NavController
 import uk.gov.android.ui.componentsv2.button.ButtonType
 import uk.gov.android.ui.componentsv2.button.GdsButton
 import uk.gov.android.ui.componentsv2.heading.GdsHeading
+import uk.gov.android.ui.componentsv2.heading.GdsHeadingAlignment
 import uk.gov.android.ui.componentsv2.warning.GdsWarningText
 import uk.gov.android.ui.patterns.leftalignedscreen.LeftAlignedScreen
 import uk.gov.android.ui.theme.m3.GdsTheme
@@ -68,6 +69,7 @@ internal fun ConfirmBrpScreenContent(
             title = { horizontalPadding ->
                 GdsHeading(
                     text = title,
+                    textAlign = GdsHeadingAlignment.LeftAligned,
                     modifier = Modifier.padding(horizontal = horizontalPadding),
                 )
             },

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/brp/select/SelectBrpScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/brp/select/SelectBrpScreen.kt
@@ -21,6 +21,7 @@ import uk.gov.android.ui.componentsv2.bulletedlist.TitleType.Text
 import uk.gov.android.ui.componentsv2.button.ButtonType
 import uk.gov.android.ui.componentsv2.button.GdsButton
 import uk.gov.android.ui.componentsv2.heading.GdsHeading
+import uk.gov.android.ui.componentsv2.heading.GdsHeadingAlignment
 import uk.gov.android.ui.componentsv2.inputs.radio.GdsSelection
 import uk.gov.android.ui.componentsv2.inputs.radio.RadioSelectionTitle
 import uk.gov.android.ui.componentsv2.warning.GdsWarningText
@@ -85,6 +86,7 @@ internal fun SelectBrpScreenContent(
         title = { horizontalPadding ->
             GdsHeading(
                 stringResource(SelectBrpConstants.titleId),
+                textAlign = GdsHeadingAlignment.LeftAligned,
                 modifier = Modifier.padding(horizontal = horizontalPadding),
             )
         },

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/drivinglicence/confirm/ConfirmDrivingLicenceScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/drivinglicence/confirm/ConfirmDrivingLicenceScreen.kt
@@ -19,6 +19,7 @@ import androidx.navigation.NavController
 import uk.gov.android.ui.componentsv2.button.ButtonType
 import uk.gov.android.ui.componentsv2.button.GdsButton
 import uk.gov.android.ui.componentsv2.heading.GdsHeading
+import uk.gov.android.ui.componentsv2.heading.GdsHeadingAlignment
 import uk.gov.android.ui.patterns.leftalignedscreen.LeftAlignedScreen
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.android.ui.theme.util.UnstableDesignSystemAPI
@@ -67,6 +68,7 @@ internal fun ConfirmDrivingLicenceScreenContent(
             title = { horizontalPadding ->
                 GdsHeading(
                     text = title,
+                    textAlign = GdsHeadingAlignment.LeftAligned,
                     modifier = Modifier.padding(horizontal = horizontalPadding),
                 )
             },

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/drivinglicence/select/SelectDrivingLicenceScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/drivinglicence/select/SelectDrivingLicenceScreen.kt
@@ -25,6 +25,7 @@ import kotlinx.collections.immutable.toPersistentList
 import uk.gov.android.ui.componentsv2.button.ButtonType
 import uk.gov.android.ui.componentsv2.button.GdsButton
 import uk.gov.android.ui.componentsv2.heading.GdsHeading
+import uk.gov.android.ui.componentsv2.heading.GdsHeadingAlignment
 import uk.gov.android.ui.componentsv2.inputs.radio.GdsSelection
 import uk.gov.android.ui.componentsv2.inputs.radio.RadioSelectionTitle
 import uk.gov.android.ui.componentsv2.inputs.radio.TitleType
@@ -98,6 +99,7 @@ internal fun SelectDrivingLicenceScreenContent(
             title = { horizontalPadding ->
                 GdsHeading(
                     text = stringResource(SelectDrivingLicenceConstants.titleId),
+                    textAlign = GdsHeadingAlignment.LeftAligned,
                     modifier = Modifier.padding(horizontal = horizontalPadding),
                 )
             },

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/confirm/ConfirmPassportScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/confirm/ConfirmPassportScreen.kt
@@ -19,6 +19,7 @@ import androidx.navigation.NavController
 import uk.gov.android.ui.componentsv2.button.ButtonType
 import uk.gov.android.ui.componentsv2.button.GdsButton
 import uk.gov.android.ui.componentsv2.heading.GdsHeading
+import uk.gov.android.ui.componentsv2.heading.GdsHeadingAlignment
 import uk.gov.android.ui.patterns.leftalignedscreen.LeftAlignedScreen
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.android.ui.theme.util.UnstableDesignSystemAPI
@@ -67,6 +68,7 @@ internal fun ConfirmPassportScreenContent(
             title = { horizontalPadding ->
                 GdsHeading(
                     text = title,
+                    textAlign = GdsHeadingAlignment.LeftAligned,
                     modifier = Modifier.padding(horizontal = horizontalPadding),
                 )
             },

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/select/SelectPassportScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/select/SelectPassportScreen.kt
@@ -23,6 +23,7 @@ import kotlinx.collections.immutable.toPersistentList
 import uk.gov.android.ui.componentsv2.button.ButtonType
 import uk.gov.android.ui.componentsv2.button.GdsButton
 import uk.gov.android.ui.componentsv2.heading.GdsHeading
+import uk.gov.android.ui.componentsv2.heading.GdsHeadingAlignment
 import uk.gov.android.ui.componentsv2.inputs.radio.GdsSelection
 import uk.gov.android.ui.componentsv2.inputs.radio.RadioSelectionTitle
 import uk.gov.android.ui.componentsv2.inputs.radio.TitleType
@@ -87,6 +88,7 @@ internal fun SelectPassportScreenContent(
             title = { horizontalPadding ->
                 GdsHeading(
                     text = stringResource(SelectPassportConstants.titleId),
+                    textAlign = GdsHeadingAlignment.LeftAligned,
                     modifier = Modifier.padding(horizontal = horizontalPadding),
                 )
             },

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/photoid/TypesOfPhotoIDScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/photoid/TypesOfPhotoIDScreen.kt
@@ -4,7 +4,6 @@ import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -13,7 +12,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import kotlinx.collections.immutable.ImmutableList
@@ -23,6 +21,8 @@ import uk.gov.android.ui.componentsv2.bulletedlist.BulletedListTitle
 import uk.gov.android.ui.componentsv2.bulletedlist.GdsBulletedList
 import uk.gov.android.ui.componentsv2.bulletedlist.TitleType.Text
 import uk.gov.android.ui.componentsv2.heading.GdsHeading
+import uk.gov.android.ui.componentsv2.heading.GdsHeadingAlignment
+import uk.gov.android.ui.componentsv2.heading.GdsHeadingStyle
 import uk.gov.android.ui.patterns.leftalignedscreen.LeftAlignedScreen
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.android.ui.theme.spacingDouble
@@ -55,6 +55,7 @@ internal fun TypesOfPhotoIDScreenContent(modifier: Modifier = Modifier) {
             title = { horizontalPadding ->
                 GdsHeading(
                     text = stringResource(TypesOfPhotoIDConstants.titleId),
+                    textAlign = GdsHeadingAlignment.LeftAligned,
                     modifier =
                         Modifier.padding(
                             horizontal = horizontalPadding,
@@ -181,8 +182,8 @@ private fun PhotoIDInformation(
     ) {
         GdsHeading(
             text = title,
-            fontWeight = FontWeight.W700,
-            style = LocalTextStyle.current,
+            textAlign = GdsHeadingAlignment.LeftAligned,
+            style = GdsHeadingStyle.Body,
             modifier =
                 Modifier
                     .padding(horizontal = horizontalPadding)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ testparameterinjector = "1.18"
 turbine = "1.2.0"
 uk-gov-logging = "0.21.0" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.6.0"
-uk-gov-ui = "7.17.2"
+uk-gov-ui = "7.18.1"
 gov-uk-idcheck = "0.6.74"
 
 [libraries]


### PR DESCRIPTION
# Upgrade UI library to the latest version

- Bumped UI library version from 7.17.2 to 7.18.1
- Add `textAlign = GdsHeadingAlignment.LeftAligned` to ensure titles in screens using the `LeftAlignedScreen` pattern are left aligned.
- Fix breaking changes to sub-headings in `TypesOfPhotoIDScreen`

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
