### PR TITLE
fix: Bypass backend setting is not respected on restarting journey

### DIFF
--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/RemoteSessionReader.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/RemoteSessionReader.kt
@@ -13,6 +13,7 @@ import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.Sessi
 import uk.gov.onelogin.criorchestrator.libraries.di.CompositionScope
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 import javax.inject.Inject
+import javax.inject.Provider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @CompositionScope
@@ -21,7 +22,7 @@ class RemoteSessionReader
     @Inject
     constructor(
         private val sessionStore: SessionStore,
-        private val sessionApi: SessionApi,
+        private val sessionApi: Provider<SessionApi>,
         private val logger: Logger,
     ) : SessionReader,
         LogTagProvider {
@@ -32,7 +33,7 @@ class RemoteSessionReader
         }
 
         override suspend fun isActiveSession(): Boolean {
-            val response = sessionApi.getActiveSession()
+            val response = sessionApi.get().getActiveSession()
             logResponse(response)
             val session = parseSession(response)
             sessionStore.write(session)

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
@@ -20,6 +20,7 @@ import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.Sessi
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionStore
 import uk.gov.onelogin.criorchestrator.libraries.testing.networking.Imposter
 import uk.gov.onelogin.criorchestrator.libraries.testing.networking.createTestHttpClient
+import javax.inject.Provider
 
 @ExperimentalCoroutinesApi
 class IntegrationTest {
@@ -52,7 +53,7 @@ class IntegrationTest {
         remoteSessionReader =
             RemoteSessionReader(
                 sessionStore = sessionStore,
-                sessionApi = sessionApi,
+                sessionApi = Provider { sessionApi },
                 logger = logger,
             )
     }

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
@@ -21,6 +21,7 @@ import uk.gov.onelogin.criorchestrator.features.session.internal.network.RemoteS
 import uk.gov.onelogin.criorchestrator.features.session.internal.network.data.InMemorySessionStore
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionReader
 import java.util.stream.Stream
+import javax.inject.Provider
 
 @ExperimentalCoroutinesApi
 class RemoteSessionReaderTest {
@@ -34,7 +35,7 @@ class RemoteSessionReaderTest {
         remoteSessionReader =
             RemoteSessionReader(
                 sessionStore = InMemorySessionStore(logger),
-                sessionApi = sessionApi,
+                sessionApi = Provider { sessionApi },
                 logger = logger,
             )
     }

--- a/sdk/public-api/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/sdk/publicapi/SdkTestConfig.kt
+++ b/sdk/public-api/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/sdk/publicapi/SdkTestConfig.kt
@@ -10,13 +10,16 @@ import uk.gov.onelogin.criorchestrator.features.resume.publicapi.nfc.NfcConfigKe
  *
  * All stubs are enabled.
  */
-fun Config.Companion.createTestInstance(isNfcAvailable: Boolean = true): Config =
+fun Config.Companion.createTestInstance(
+    isNfcAvailable: Boolean = true,
+    bypassIdCheckAsyncBackend: Boolean = true,
+): Config =
     Config(
         entries =
             persistentListOf(
                 Config.Entry<Config.Value.BooleanValue>(
                     key = SdkConfigKey.BypassIdCheckAsyncBackend,
-                    value = Config.Value.BooleanValue(true),
+                    value = Config.Value.BooleanValue(bypassIdCheckAsyncBackend),
                 ),
                 Config.Entry<Config.Value.StringValue>(
                     key = SdkConfigKey.IdCheckAsyncBackendBaseUrl,


### PR DESCRIPTION
## Changes

Ensure the 'bypass ID Check async backend' config is respected after it's changed.

## Context

DCMAW-12844

## Evidence of the change

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
