### PR TITLE
feat: Handle different ID Check SDK exit states

### DIFF
--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/model/ExitStateOption.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/model/ExitStateOption.kt
@@ -1,15 +1,35 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.model
 
+import android.content.Intent
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import uk.gov.idcheck.sdk.IdCheckSdkExitState
+import uk.gov.idcheck.ui.presentation.dialogs.confirmanotherway.ConfirmationAbortedNavModel
 
+/**
+ * The set of ID Check SDK results that can be forced for testing.
+ */
 enum class ExitStateOption(
     val exitState: IdCheckSdkExitState?,
     val displayName: String,
 ) {
     None(displayName = "None"),
     HappyPath(IdCheckSdkExitState.HappyPath),
+    ConfirmAnotherWay(
+        IdCheckSdkExitState.ConfirmAnotherWay(STUB_SCREEN_VIEW_NAME),
+    ),
+    ConfirmationAbortedJourney(
+        IdCheckSdkExitState.ConfirmationAbortedJourney(stubConfirmationAbortedNavModel),
+    ),
+    ConfirmationFailed(IdCheckSdkExitState.ConfirmationFailed),
+    FaceScanLimitReached(
+        IdCheckSdkExitState.FaceScanLimitReached(
+            handoverSessionId = STUB_SESSION_ID,
+            readIdSessionId = STUB_SESSION_ID,
+        ),
+    ),
+    UnknownDocumentType(IdCheckSdkExitState.UnknownDocumentType),
+    Nowhere(IdCheckSdkExitState.Nowhere),
     ;
 
     constructor(
@@ -35,3 +55,14 @@ enum class ExitStateOption(
                     }.toPersistentList()
     }
 }
+
+private const val STUB_SCREEN_VIEW_NAME = "stubScreenViewName"
+private const val STUB_SESSION_ID = "stubSessionId"
+
+private val stubConfirmationAbortedNavModel =
+    ConfirmationAbortedNavModel(
+        section = "section",
+        additionalInfoText = "additionalInfoText",
+        substringToColour = "substringToColour",
+        intentToStart = Intent(),
+    )

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckAction.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckAction.kt
@@ -9,7 +9,11 @@ sealed interface SyncIdCheckAction {
         val logger: Logger,
     ) : SyncIdCheckAction
 
-    object NavigateToReturnToMobileWeb : SyncIdCheckAction
+    data object NavigateToReturnToMobileWeb : SyncIdCheckAction
 
-    object NavigateToReturnToDesktopWeb : SyncIdCheckAction
+    data object NavigateToReturnToDesktopWeb : SyncIdCheckAction
+
+    data object NavigateToConfirmAbortToMobileWeb : SyncIdCheckAction
+
+    data object NavigateToConfirmAbortToDesktopWeb : SyncIdCheckAction
 }

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreen.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.navigation.NavController
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import uk.gov.android.ui.componentsv2.button.ButtonType
 import uk.gov.android.ui.componentsv2.button.GdsButton
 import uk.gov.android.ui.componentsv2.heading.GdsHeading
@@ -34,6 +34,7 @@ import uk.gov.idcheck.repositories.api.webhandover.journeytype.JourneyType
 import uk.gov.onelogin.criorchestrator.features.handback.internalapi.nav.HandbackDestinations
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.activity.UnavailableIdCheckSdkActivityResultContract
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.activity.toIdCheckSdkActivityParameters
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.model.ExitStateOption
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.model.LauncherData
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.Session
@@ -89,6 +90,13 @@ internal fun SyncIdCheckScreen(
                     navController.navigate(
                         HandbackDestinations.ReturnToDesktopWeb,
                     )
+
+                SyncIdCheckAction.NavigateToConfirmAbortToDesktopWeb,
+                SyncIdCheckAction.NavigateToConfirmAbortToMobileWeb,
+                ->
+                    navController.navigate(
+                        HandbackDestinations.ConfirmAbort,
+                    )
             }
         }
     }
@@ -102,7 +110,7 @@ internal fun SyncIdCheckScreen(
                         selectedExitState = state.manualLauncher.selectedExitState,
                         exitStateOptions = state.manualLauncher.exitStateOptions,
                         onLaunchRequest = { viewModel.onIdCheckSdkLaunchRequest(state.launcherData) },
-                        onExitStateSelected = viewModel::onStubExitStateSelected,
+                        onExitStateSelected = { viewModel.onStubExitStateSelected(it) },
                     )
                 } else {
                     SyncIdCheckAutomaticLauncherContent(
@@ -228,7 +236,7 @@ internal fun PreviewSyncIdCheckManualLauncherContent() {
                             opaqueId = "test opaque ID",
                         ),
                 ),
-            exitStateOptions = persistentListOf("None", "Happy Path"),
+            exitStateOptions = ExitStateOption.entries.map { it.displayName }.toPersistentList(),
             selectedExitState = 0,
             onExitStateSelected = {},
             onLaunchRequest = {},

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenTest.kt
@@ -1,9 +1,10 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.screen
 
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.navigation.NavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
@@ -27,8 +28,9 @@ class SyncIdCheckScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    private val launchButton = hasText("Launch ID Check SDK")
-    private val happyPathOption = hasText("Happy path")
+    private val launchButton = "Launch ID Check SDK"
+    private val happyPathOption = "Happy path"
+    private val unhappyPathOption = "Confirm identity another way"
 
     private val navController: NavController = mock()
 
@@ -58,13 +60,9 @@ class SyncIdCheckScreenTest {
         enableManualLauncher = true
         session = Session.createMobileAppMobileInstance()
         composeTestRule.setScreenContent()
-        composeTestRule
-            .onNode(happyPathOption, useUnmergedTree = true)
-            .performClick()
 
-        composeTestRule
-            .onNode(launchButton)
-            .performClick()
+        composeTestRule.selectOption(happyPathOption)
+        composeTestRule.clickLaunchButton()
 
         composeTestRule.waitForIdle()
 
@@ -78,13 +76,9 @@ class SyncIdCheckScreenTest {
         enableManualLauncher = true
         session = Session.createDesktopAppDesktopInstance()
         composeTestRule.setScreenContent()
-        composeTestRule
-            .onNode(happyPathOption, useUnmergedTree = true)
-            .performClick()
 
-        composeTestRule
-            .onNode(launchButton)
-            .performClick()
+        composeTestRule.selectOption(happyPathOption)
+        composeTestRule.clickLaunchButton()
 
         composeTestRule.waitForIdle()
 
@@ -92,6 +86,48 @@ class SyncIdCheckScreenTest {
             HandbackDestinations.ReturnToDesktopWeb,
         )
     }
+
+    @Test
+    fun `manual launch with MAM session, when launch unhappy path, navigates to confirm abort MAM`() {
+        enableManualLauncher = true
+        session = Session.createMobileAppMobileInstance()
+        composeTestRule.setScreenContent()
+
+        composeTestRule.selectOption(unhappyPathOption)
+        composeTestRule.clickLaunchButton()
+
+        composeTestRule.waitForIdle()
+
+        verify(navController).navigate(
+            HandbackDestinations.ConfirmAbort,
+        )
+    }
+
+    @Test
+    @Suppress("")
+    fun `manual launch with DAD session, when launch unhappy path, navigates to confirm abort DAD`() {
+        enableManualLauncher = true
+        session = Session.createDesktopAppDesktopInstance()
+        composeTestRule.setScreenContent()
+
+        composeTestRule.selectOption(unhappyPathOption)
+        composeTestRule.clickLaunchButton()
+
+        composeTestRule.waitForIdle()
+
+        verify(navController).navigate(
+            HandbackDestinations.ConfirmAbort,
+        )
+    }
+
+    private fun ComposeContentTestRule.selectOption(text: String) =
+        onNodeWithText(text, useUnmergedTree = true)
+            .performScrollTo()
+            .performClick()
+
+    private fun ComposeContentTestRule.clickLaunchButton() =
+        onNodeWithText(launchButton)
+            .performClick()
 
     private fun ComposeContentTestRule.setScreenContent() =
         setContent {

--- a/features/id-check-wrapper/internal/src/test/snapshots/images/features.idcheckwrapper.internal.screen_SyncIdCheckScreenKt_PreviewSyncIdCheckManualLauncherContent_Dark_NIGHT.png
+++ b/features/id-check-wrapper/internal/src/test/snapshots/images/features.idcheckwrapper.internal.screen_SyncIdCheckScreenKt_PreviewSyncIdCheckManualLauncherContent_Dark_NIGHT.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2d0edaa927c696baf8f5d8f00387b4155bef0aed127bfce68c153548f1d8c9e
-size 40619
+oid sha256:3be739864f7a972df4d925b9f4dd9e79fc119b4ee1055b783ea412247282eaba
+size 63010

--- a/features/id-check-wrapper/internal/src/test/snapshots/images/features.idcheckwrapper.internal.screen_SyncIdCheckScreenKt_PreviewSyncIdCheckManualLauncherContent_Light.png
+++ b/features/id-check-wrapper/internal/src/test/snapshots/images/features.idcheckwrapper.internal.screen_SyncIdCheckScreenKt_PreviewSyncIdCheckManualLauncherContent_Light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0eb276d0d9ac66c52398d4bacc1781b0716ab007fbc3a16205ffcb4d9d86272d
-size 41042
+oid sha256:3cb731a686fbde4b8f778f61d6a096014c71d3b83b98b4e5a5a2e259e05114bf
+size 64528

--- a/features/id-check-wrapper/internal/src/test/snapshots/images/features.idcheckwrapper.internal.screen_SyncIdCheckScreenKt_PreviewSyncIdCheckManualLauncherContent_cy.png
+++ b/features/id-check-wrapper/internal/src/test/snapshots/images/features.idcheckwrapper.internal.screen_SyncIdCheckScreenKt_PreviewSyncIdCheckManualLauncherContent_cy.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0eb276d0d9ac66c52398d4bacc1781b0716ab007fbc3a16205ffcb4d9d86272d
-size 41042
+oid sha256:3cb731a686fbde4b8f778f61d6a096014c71d3b83b98b4e5a5a2e259e05114bf
+size 64528


### PR DESCRIPTION
## Changes

Allow testers to force all possible ID Check SDK results when the manual launcher is enabled.

## Context

DCMAW-11490

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [x] Check against acceptance criteria
- [x] Add automated tests
- [x] Self-review code
