### PR TITLE
refactor: pass DocumentVariety instead of strings in biometricToken api

### DIFF
--- a/features/id-check-wrapper/internal/build.gradle.kts
+++ b/features/id-check-wrapper/internal/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     testFixturesImplementation(libs.uk.gov.idcheck.repositories.api)
     testFixturesImplementation(libs.uk.gov.idcheck.sdk)
     testFixturesImplementation(libs.uk.gov.idcheck.ui.presentation)
+    testFixturesImplementation(projects.features.idCheckWrapper.internalApi)
     testFixturesImplementation(projects.features.session.internalApi)
     testFixturesImplementation(testFixtures(projects.features.config.internalApi))
     testFixturesImplementation(testFixtures(projects.features.config.publicApi))

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApi.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApi.kt
@@ -1,10 +1,11 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken
 
 import uk.gov.android.network.api.ApiResponse
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 
 fun interface BiometricApi {
     suspend fun getBiometricToken(
         sessionId: String,
-        documentType: String,
+        documentVariety: DocumentVariety,
     ): ApiResponse
 }

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImpl.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImpl.kt
@@ -8,6 +8,8 @@ import uk.gov.logging.api.LogTagProvider
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey.IdCheckAsyncBackendBaseUrl
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.data.BiometricApiRequest.BiometricRequest
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.nav.toDocumentType
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 import javax.inject.Inject
 
 private const val BIOMETRIC_TOKEN_ENDPOINT = "/async/biometricToken"
@@ -21,7 +23,7 @@ class BiometricApiImpl
         LogTagProvider {
         override suspend fun getBiometricToken(
             sessionId: String,
-            documentType: String,
+            documentVariety: DocumentVariety,
         ): ApiResponse {
             val request =
                 ApiRequest.Post(
@@ -29,7 +31,7 @@ class BiometricApiImpl
                     body =
                         BiometricRequest(
                             sessionId,
-                            documentType,
+                            documentVariety.toDocumentType().backendRepresentation,
                         ),
                     contentType = ContentType.APPLICATION_JSON,
                 )

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricTokenReader.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricTokenReader.kt
@@ -1,8 +1,10 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken
 
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
+
 fun interface BiometricTokenReader {
     suspend fun getBiometricToken(
         sessionId: String,
-        documentType: String,
+        documentVariety: DocumentVariety,
     ): BiometricTokenResult
 }

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/FakeBiometricTokenApi.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/FakeBiometricTokenApi.kt
@@ -3,6 +3,7 @@ package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometr
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import uk.gov.android.network.api.ApiResponse
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 import javax.inject.Inject
 
 class FakeBiometricTokenApi
@@ -16,7 +17,7 @@ class FakeBiometricTokenApi
 
         override suspend fun getBiometricToken(
             sessionId: String,
-            documentType: String,
+            documentVariety: DocumentVariety,
         ): ApiResponse {
             val response =
                 BiometricToken(

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/RemoteBiometricTokenReader.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/RemoteBiometricTokenReader.kt
@@ -8,6 +8,7 @@ import uk.gov.logging.api.LogTagProvider
 import uk.gov.logging.api.Logger
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.data.BiometricApiResponse
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.data.ConfigurableBiometricApi
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 import uk.gov.onelogin.criorchestrator.libraries.di.CompositionScope
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 import javax.inject.Inject
@@ -29,9 +30,9 @@ class RemoteBiometricTokenReader
 
         override suspend fun getBiometricToken(
             sessionId: String,
-            documentType: String,
+            documentVariety: DocumentVariety,
         ): BiometricTokenResult {
-            val response = biometricApi.getBiometricToken(sessionId, documentType)
+            val response = biometricApi.getBiometricToken(sessionId, documentVariety)
 
             return when (response) {
                 ApiResponse.Offline -> BiometricTokenResult.Offline

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/data/ConfigurableBiometricApi.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/data/ConfigurableBiometricApi.kt
@@ -7,6 +7,7 @@ import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.BiometricApi
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.BiometricApiImpl
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.FakeBiometricTokenApi
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 import javax.inject.Inject
 
@@ -20,11 +21,11 @@ class ConfigurableBiometricApi
     ) : BiometricApi {
         override suspend fun getBiometricToken(
             sessionId: String,
-            documentType: String,
+            documentVariety: DocumentVariety,
         ): ApiResponse =
             if (configStore.readSingle(SdkConfigKey.BypassIdCheckAsyncBackend).value) {
-                fakeBiometricApi.getBiometricToken(sessionId, documentType)
+                fakeBiometricApi.getBiometricToken(sessionId, documentVariety)
             } else {
-                realBiometricApi.getBiometricToken(sessionId, documentType)
+                realBiometricApi.getBiometricToken(sessionId, documentVariety)
             }
     }

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/data/LauncherDataReader.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/data/LauncherDataReader.kt
@@ -30,7 +30,7 @@ class LauncherDataReader
                     .timeout(10.seconds)
                     .first()
 
-            val result = biometricTokenReader.getBiometricToken(session.sessionId, documentVariety.name)
+            val result = biometricTokenReader.getBiometricToken(session.sessionId, documentVariety)
             return when (result) {
                 is BiometricTokenResult.Error -> {
                     LauncherDataReaderResult.UnrecoverableError(

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImplTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImplTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken
 
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -18,7 +17,6 @@ import uk.gov.android.network.client.ContentType
 import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.FakeConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
-import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey.IdCheckAsyncBackendBaseUrl
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.data.BiometricApiRequest.BiometricRequest
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
@@ -80,16 +78,16 @@ class BiometricApiImplTest {
             )
         runTest {
             whenever(
-                mockHttpClient.makeRequest(any())
+                mockHttpClient.makeRequest(any()),
             ).thenReturn(
                 ApiResponse.Success<String>(
                     "{\"accessToken\":\"string\",\"opaqueId\":\"6ec96ea7-941c-4967-9fcf-94fc9b717a22\"}",
-                )
+                ),
             )
             biometricApiImpl.getBiometricToken("sessionId", documentVariety)
 
             verify(
-                mockHttpClient
+                mockHttpClient,
             ).makeRequest(
                 ApiRequest.Post(
                     url = "$imposterBaseUrl/async/biometricToken",
@@ -99,7 +97,7 @@ class BiometricApiImplTest {
                             expectedDocumentString,
                         ),
                     contentType = ContentType.APPLICATION_JSON,
-                )
+                ),
             )
         }
     }

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImplTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImplTest.kt
@@ -1,29 +1,47 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.android.network.api.ApiRequest
 import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.client.ContentType
+import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.FakeConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
+import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey.IdCheckAsyncBackendBaseUrl
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.data.BiometricApiRequest.BiometricRequest
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 import uk.gov.onelogin.criorchestrator.libraries.testing.networking.Imposter
 import uk.gov.onelogin.criorchestrator.libraries.testing.networking.createTestHttpClient
+import java.util.stream.Stream
 import kotlin.test.assertEquals
 
 class BiometricApiImplTest {
-    lateinit var biometricApiImpl: BiometricApi
+    private lateinit var biometricApiImpl: BiometricApi
+    private lateinit var imposterBaseUrl: String
     private val fakeConfigStore = FakeConfigStore()
 
     @BeforeEach
     fun setup() {
         val imposter = Imposter.createMockEngine()
+        imposterBaseUrl = imposter.baseUrl.toString()
         fakeConfigStore.write(
             Config.Entry(
-                key = SdkConfigKey.IdCheckAsyncBackendBaseUrl,
+                key = IdCheckAsyncBackendBaseUrl,
                 value =
                     Config.Value.StringValue(
-                        imposter.baseUrl.toString(),
+                        imposterBaseUrl,
                     ),
             ),
         )
@@ -43,7 +61,66 @@ class BiometricApiImplTest {
                     "{\"accessToken\":\"string\",\"opaqueId\":\"6ec96ea7-941c-4967-9fcf-94fc9b717a22\"}",
                 )
 
-            val result = biometricApiImpl.getBiometricToken("sessionId", "documentType")
+            val result =
+                biometricApiImpl.getBiometricToken("sessionId", DocumentVariety.NFC_PASSPORT)
             assertEquals(expected, result)
         }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("assertBackendApiUsesCorrectStringForRequest")
+    fun `assert backend API uses correct string for API request`(
+        expectedDocumentString: String,
+        documentVariety: DocumentVariety,
+    ) {
+        val mockHttpClient: GenericHttpClient = mock()
+        biometricApiImpl =
+            BiometricApiImpl(
+                httpClient = mockHttpClient,
+                configStore = fakeConfigStore,
+            )
+        runTest {
+            whenever(
+                mockHttpClient.makeRequest(any())
+            ).thenReturn(
+                ApiResponse.Success<String>(
+                    "{\"accessToken\":\"string\",\"opaqueId\":\"6ec96ea7-941c-4967-9fcf-94fc9b717a22\"}",
+                )
+            )
+            biometricApiImpl.getBiometricToken("sessionId", documentVariety)
+
+            verify(
+                mockHttpClient
+            ).makeRequest(
+                ApiRequest.Post(
+                    url = "$imposterBaseUrl/async/biometricToken",
+                    body =
+                        BiometricRequest(
+                            "sessionId",
+                            expectedDocumentString,
+                        ),
+                    contentType = ContentType.APPLICATION_JSON,
+                )
+            )
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        @Suppress("LongMethod")
+        fun assertBackendApiUsesCorrectStringForRequest(): Stream<Arguments> =
+            Stream.of(
+                arguments(
+                    "NFC_PASSPORT",
+                    DocumentVariety.NFC_PASSPORT,
+                ),
+                arguments(
+                    "UK_DRIVING_LICENCE",
+                    DocumentVariety.DRIVING_LICENCE,
+                ),
+                arguments(
+                    "UK_NFC_BRP",
+                    DocumentVariety.BRP,
+                ),
+            )
+    }
 }

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImplTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImplTest.kt
@@ -66,7 +66,7 @@ class BiometricApiImplTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("assertBackendApiUsesCorrectStringForRequest")
-    fun `assert backend API uses correct string for API request`(
+    fun `assert backend API uses correct string for API request given document type`(
         expectedDocumentString: String,
         documentVariety: DocumentVariety,
     ) {
@@ -104,7 +104,6 @@ class BiometricApiImplTest {
 
     companion object {
         @JvmStatic
-        @Suppress("LongMethod")
         fun assertBackendApiUsesCorrectStringForRequest(): Stream<Arguments> =
             Stream.of(
                 arguments(

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/IntegrationTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/IntegrationTest.kt
@@ -18,7 +18,6 @@ import kotlin.test.assertTrue
 private const val SESSION_ID = "session_id"
 
 class IntegrationTest {
-
     private val documentType = DocumentVariety.NFC_PASSPORT
     private val configStore = FakeConfigStore()
     private val logger = SystemLogger()

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/IntegrationTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/IntegrationTest.kt
@@ -9,15 +9,17 @@ import uk.gov.onelogin.criorchestrator.features.config.internalapi.FakeConfigSto
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.data.ConfigurableBiometricApi
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 import uk.gov.onelogin.criorchestrator.libraries.testing.networking.Imposter
 import uk.gov.onelogin.criorchestrator.libraries.testing.networking.createTestHttpClient
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 private const val SESSION_ID = "session_id"
-private const val DOCUMENT_TYPE = "document_type"
 
 class IntegrationTest {
+
+    private val documentType = DocumentVariety.NFC_PASSPORT
     private val configStore = FakeConfigStore()
     private val logger = SystemLogger()
     private val imposter = Imposter.createMockEngine()
@@ -66,7 +68,7 @@ class IntegrationTest {
                     ),
                 )
 
-            val result = biometricTokenReader.getBiometricToken(SESSION_ID, DOCUMENT_TYPE)
+            val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
 
             assertEquals(expected, result)
             assertTrue(logger.contains("Got the biometric token"))
@@ -83,7 +85,7 @@ class IntegrationTest {
         )
 
         runTest {
-            val result = biometricTokenReader.getBiometricToken(SESSION_ID, DOCUMENT_TYPE)
+            val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
 
             assert(result is BiometricTokenResult.Error)
         }
@@ -98,7 +100,7 @@ class IntegrationTest {
             ),
         )
         runTest {
-            val result = biometricTokenReader.getBiometricToken(SESSION_ID, DOCUMENT_TYPE)
+            val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
 
             assert(result is BiometricTokenResult.Error)
         }
@@ -113,7 +115,7 @@ class IntegrationTest {
             ),
         )
         runTest {
-            val result = biometricTokenReader.getBiometricToken(SESSION_ID, DOCUMENT_TYPE)
+            val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
 
             assert(result is BiometricTokenResult.Error)
         }
@@ -128,7 +130,7 @@ class IntegrationTest {
             ),
         )
         runTest {
-            val result = biometricTokenReader.getBiometricToken(SESSION_ID, DOCUMENT_TYPE)
+            val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
 
             assert(result is BiometricTokenResult.Error)
         }

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/RemoteBiometricTokenReaderTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/RemoteBiometricTokenReaderTest.kt
@@ -10,12 +10,14 @@ import uk.gov.android.network.api.ApiResponse
 import uk.gov.logging.api.Logger
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.data.BiometricApiResponse
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.data.ConfigurableBiometricApi
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 
 private const val SESSION_ID = "session_id"
-private const val DOCUMENT_TYPE = "document_type"
 
 class RemoteBiometricTokenReaderTest {
     private lateinit var biometricTokenReader: BiometricTokenReader
+
+    private val documentType = DocumentVariety.NFC_PASSPORT
     private val biometricApi = mock<ConfigurableBiometricApi>()
     private val logger = mock<Logger>()
     private val json = Json { ignoreUnknownKeys = true }
@@ -35,13 +37,13 @@ class RemoteBiometricTokenReaderTest {
             whenever(
                 biometricApi.getBiometricToken(
                     SESSION_ID,
-                    DOCUMENT_TYPE,
+                    documentType,
                 ),
             ).thenReturn(
                 ApiResponse.Loading,
             )
 
-            val result = biometricTokenReader.getBiometricToken(SESSION_ID, DOCUMENT_TYPE)
+            val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
 
             assert(result is BiometricTokenResult.Error)
         }
@@ -52,13 +54,13 @@ class RemoteBiometricTokenReaderTest {
             whenever(
                 biometricApi.getBiometricToken(
                     SESSION_ID,
-                    DOCUMENT_TYPE,
+                    documentType,
                 ),
             ).thenReturn(
                 ApiResponse.Offline,
             )
 
-            val result = biometricTokenReader.getBiometricToken(SESSION_ID, DOCUMENT_TYPE)
+            val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
 
             assert(result is BiometricTokenResult.Offline)
         }
@@ -69,11 +71,11 @@ class RemoteBiometricTokenReaderTest {
             whenever(
                 biometricApi.getBiometricToken(
                     SESSION_ID,
-                    DOCUMENT_TYPE,
+                    documentType,
                 ),
             ).thenReturn(ApiResponse.Failure(status = 400, error = Exception("error")))
 
-            val result = biometricTokenReader.getBiometricToken(SESSION_ID, DOCUMENT_TYPE)
+            val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
             val error = result as BiometricTokenResult.Error
 
             assert(result == error)
@@ -94,11 +96,11 @@ class RemoteBiometricTokenReaderTest {
             whenever(
                 biometricApi.getBiometricToken(
                     SESSION_ID,
-                    DOCUMENT_TYPE,
+                    documentType,
                 ),
             ).thenReturn(ApiResponse.Success(encoded))
 
-            val result = biometricTokenReader.getBiometricToken(SESSION_ID, DOCUMENT_TYPE)
+            val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
 
             assert(result is BiometricTokenResult.Success)
         }
@@ -109,10 +111,10 @@ class RemoteBiometricTokenReaderTest {
             whenever(
                 biometricApi.getBiometricToken(
                     SESSION_ID,
-                    DOCUMENT_TYPE,
+                    documentType,
                 ),
             ).thenReturn(ApiResponse.Success("invalid json"))
-            val result = biometricTokenReader.getBiometricToken(SESSION_ID, DOCUMENT_TYPE)
+            val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
             assert(result is BiometricTokenResult.Error)
         }
 }

--- a/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/StubBiometricTokenReader.kt
+++ b/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/StubBiometricTokenReader.kt
@@ -1,6 +1,7 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken
 
 import kotlinx.coroutines.delay
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 
 class StubBiometricTokenReader(
     private val biometricTokenResult: BiometricTokenResult,
@@ -8,7 +9,7 @@ class StubBiometricTokenReader(
 ) : BiometricTokenReader {
     override suspend fun getBiometricToken(
         sessionId: String,
-        documentType: String,
+        documentVariety: DocumentVariety,
     ): BiometricTokenResult {
         // Used to simulate network delay
         delay(delay)


### PR DESCRIPTION
Context
- Currently we're passing strings around in the `BiometricApi`, and the request made to the actual endpoint uses the incorrect string for the document type.

Changes
- Fix so that the actual API request uses the correct document type string.
- Refactor so that DocumentVariety is passed around instead of strings.

## Evidence of the change
To be recorded

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
