### PR TITLE
feat: create dad handback screen

### DIFF
--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/HandbackNavGraphProvider.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/HandbackNavGraphProvider.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.criorchestrator.features.handback.internal
 
-import androidx.compose.material3.Text
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
@@ -8,6 +7,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.squareup.anvil.annotations.ContributesMultibinding
 import uk.gov.onelogin.criorchestrator.features.handback.internal.confirmabort.ConfirmAbort
+import uk.gov.onelogin.criorchestrator.features.handback.internal.returntodesktopweb.ReturnToDesktopWebScreen
 import uk.gov.onelogin.criorchestrator.features.handback.internal.returntomobileweb.ReturnToMobileWebScreen
 import uk.gov.onelogin.criorchestrator.features.handback.internal.returntomobileweb.ReturnToMobileWebViewModelModule
 import uk.gov.onelogin.criorchestrator.features.handback.internal.returntomobileweb.WebNavigator
@@ -45,7 +45,7 @@ class HandbackNavGraphProvider
             }
 
             composable<HandbackDestinations.ReturnToDesktopWeb> {
-                Text("Return to GOV.UK to finish proving your identity | DCMAW-11596")
+                ReturnToDesktopWebScreen()
             }
 
             composable<HandbackDestinations.ConfirmAbort> {

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/HandbackNavGraphProvider.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/HandbackNavGraphProvider.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import com.squareup.anvil.annotations.ContributesMultibinding
 import uk.gov.onelogin.criorchestrator.features.handback.internal.confirmabort.ConfirmAbort
 import uk.gov.onelogin.criorchestrator.features.handback.internal.returntodesktopweb.ReturnToDesktopWebScreen
+import uk.gov.onelogin.criorchestrator.features.handback.internal.returntodesktopweb.ReturnToDesktopWebViewModelModule
 import uk.gov.onelogin.criorchestrator.features.handback.internal.returntomobileweb.ReturnToMobileWebScreen
 import uk.gov.onelogin.criorchestrator.features.handback.internal.returntomobileweb.ReturnToMobileWebViewModelModule
 import uk.gov.onelogin.criorchestrator.features.handback.internal.returntomobileweb.WebNavigator
@@ -27,6 +28,8 @@ class HandbackNavGraphProvider
         private val unrecoverableErrorViewModelFactory: ViewModelProvider.Factory,
         @Named(ReturnToMobileWebViewModelModule.FACTORY_NAME)
         private val returnToMobileViewModelFactory: ViewModelProvider.Factory,
+        @Named(ReturnToDesktopWebViewModelModule.FACTORY_NAME)
+        private val returnToDesktopViewModelFactory: ViewModelProvider.Factory,
         private val webNavigator: WebNavigator,
     ) : ProveYourIdentityNavGraphProvider {
         override fun NavGraphBuilder.contributeToGraph(navController: NavController) {
@@ -45,7 +48,9 @@ class HandbackNavGraphProvider
             }
 
             composable<HandbackDestinations.ReturnToDesktopWeb> {
-                ReturnToDesktopWebScreen()
+                ReturnToDesktopWebScreen(
+                    viewModel = viewModel(factory = returnToDesktopViewModelFactory),
+                )
             }
 
             composable<HandbackDestinations.ConfirmAbort> {

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/analytics/HandbackScreenId.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/analytics/HandbackScreenId.kt
@@ -7,5 +7,6 @@ enum class HandbackScreenId(
 ) : ScreenId {
     UnrecoverableError(rawId = "80069598-8c97-4789-96f8-8930fb633889"),
 
+    ReturnToDesktopWeb(rawId = "fff9c5fe-3eb2-45d4-a07a-fb6d21582c50"),
     ReturnToMobileWeb(rawId = "4a9fafaa-5359-4105-b223-a51d71df435f"),
 }

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebConstants.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebConstants.kt
@@ -1,0 +1,8 @@
+package uk.gov.onelogin.criorchestrator.features.handback.internal.returntodesktopweb
+
+import androidx.annotation.StringRes
+import uk.gov.onelogin.criorchestrator.features.handback.internal.R
+
+internal object ReturnToDesktopWebConstants {
+    @StringRes val titleId: Int = R.string.handback_returntodesktopweb_title
+}

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreen.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreen.kt
@@ -1,0 +1,74 @@
+package uk.gov.onelogin.criorchestrator.features.handback.internal.returntodesktopweb
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import uk.gov.android.ui.componentsv2.heading.GdsHeading
+import uk.gov.android.ui.componentsv2.heading.GdsHeadingAlignment
+import uk.gov.android.ui.patterns.centrealignedscreen.CentreAlignedScreen
+import uk.gov.android.ui.theme.m3.GdsTheme
+import uk.gov.android.ui.theme.util.UnstableDesignSystemAPI
+import uk.gov.onelogin.criorchestrator.features.handback.internal.R
+import uk.gov.onelogin.criorchestrator.libraries.composeutils.LightDarkBothLocalesPreview
+
+@Composable
+fun ReturnToDesktopWebScreen(modifier: Modifier = Modifier) {
+    ReturnToDesktopWebScreenContent(
+        modifier = modifier,
+    )
+}
+
+@OptIn(UnstableDesignSystemAPI::class)
+@Composable
+fun ReturnToDesktopWebScreenContent(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        color = colorScheme.background,
+    ) {
+        CentreAlignedScreen(
+            title = { horizontalPadding ->
+                GdsHeading(
+                    text = stringResource(ReturnToDesktopWebConstants.titleId),
+                    modifier = Modifier.padding(horizontal = horizontalPadding),
+                    textAlign = GdsHeadingAlignment.CenterAligned,
+                )
+            },
+            body = { horizontalPadding ->
+                item {
+                    Text(
+                        text = stringResource(R.string.handback_returntodesktopweb_body1),
+                        textAlign = TextAlign.Center,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = horizontalPadding),
+                    )
+                }
+                item {
+                    Text(
+                        text = stringResource(R.string.handback_returntodesktopweb_body2),
+                        textAlign = TextAlign.Center,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = horizontalPadding),
+                    )
+                }
+            },
+        )
+    }
+}
+
+@LightDarkBothLocalesPreview
+@Composable
+internal fun PreviewReturnToMobileWebScreen() {
+    GdsTheme {
+        ReturnToDesktopWebScreenContent()
+    }
+}

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreen.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import uk.gov.android.ui.componentsv2.heading.GdsHeading
 import uk.gov.android.ui.componentsv2.heading.GdsHeadingAlignment
@@ -45,6 +47,8 @@ fun ReturnToDesktopWebScreenContent(modifier: Modifier = Modifier) {
                     text = stringResource(ReturnToDesktopWebConstants.titleId),
                     modifier = Modifier.padding(horizontal = horizontalPadding),
                     textAlign = GdsHeadingAlignment.CenterAligned,
+                    customContentDescription =
+                        stringResource(R.string.handback_returntodesktopweb_title_content_description),
                 )
             },
             body = { horizontalPadding ->
@@ -59,13 +63,19 @@ fun ReturnToDesktopWebScreenContent(modifier: Modifier = Modifier) {
                     )
                 }
                 item {
+                    val customContentDescription =
+                        stringResource(R.string.handback_returntodesktopweb_body2_content_description)
+
                     Text(
                         text = stringResource(R.string.handback_returntodesktopweb_body2),
                         textAlign = TextAlign.Center,
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .padding(horizontal = horizontalPadding),
+                                .padding(horizontal = horizontalPadding)
+                                .semantics {
+                                    contentDescription = customContentDescription
+                                },
                     )
                 }
             },

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreen.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -18,10 +19,17 @@ import uk.gov.onelogin.criorchestrator.features.handback.internal.R
 import uk.gov.onelogin.criorchestrator.libraries.composeutils.LightDarkBothLocalesPreview
 
 @Composable
-fun ReturnToDesktopWebScreen(modifier: Modifier = Modifier) {
+fun ReturnToDesktopWebScreen(
+    viewModel: ReturnToDesktopWebViewModel,
+    modifier: Modifier = Modifier,
+) {
     ReturnToDesktopWebScreenContent(
         modifier = modifier,
     )
+
+    LaunchedEffect(Unit) {
+        viewModel.onScreenStart()
+    }
 }
 
 @OptIn(UnstableDesignSystemAPI::class)

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebViewModel.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebViewModel.kt
@@ -1,0 +1,16 @@
+package uk.gov.onelogin.criorchestrator.features.handback.internal.returntodesktopweb
+
+import androidx.lifecycle.ViewModel
+import uk.gov.onelogin.criorchestrator.features.handback.internal.analytics.HandbackAnalytics
+import uk.gov.onelogin.criorchestrator.features.handback.internal.analytics.HandbackScreenId
+
+class ReturnToDesktopWebViewModel(
+    private val analytics: HandbackAnalytics,
+) : ViewModel() {
+    fun onScreenStart() {
+        analytics.trackScreen(
+            id = HandbackScreenId.ReturnToDesktopWeb,
+            title = ReturnToDesktopWebConstants.titleId,
+        )
+    }
+}

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebViewModelModule.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebViewModelModule.kt
@@ -1,0 +1,28 @@
+package uk.gov.onelogin.criorchestrator.features.handback.internal.returntodesktopweb
+
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import uk.gov.onelogin.criorchestrator.features.handback.internal.analytics.HandbackAnalytics
+import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
+import javax.inject.Named
+
+@Module
+@ContributesTo(CriOrchestratorScope::class)
+object ReturnToDesktopWebViewModelModule {
+    const val FACTORY_NAME = "ReturnToDesktopViewModelModuleFactory"
+
+    @Provides
+    @Named(FACTORY_NAME)
+    fun provideFactory(analytics: HandbackAnalytics): ViewModelProvider.Factory =
+        viewModelFactory {
+            initializer {
+                ReturnToDesktopWebViewModel(
+                    analytics = analytics,
+                )
+            }
+        }
+}

--- a/features/handback/internal/src/main/res/values-cy/strings.xml
+++ b/features/handback/internal/src/main/res/values-cy/strings.xml
@@ -13,6 +13,8 @@
     <string name="handback_returntomobileweb_button">Parhau i wefan GOV.UK</string>
 
     <string name="handback_returntodesktopweb_title">Ewch yn ôl i GOV.UK ar eich cyfrifiadur neu dabled</string>
+    <string name="handback_returntodesktopweb_title_content_description">Ewch yn ôl i Gov dot UK ar eich cyfrifiadur neu dabled</string>
     <string name="handback_returntodesktopweb_body1">Rydych chi wedi cyflwyno’ch gwybodaeth yn llwyddiannus.</string>
     <string name="handback_returntodesktopweb_body2">I orffen profi pwy ydych chi, mae angen i chi ddychwelyd i’r dudalen GOV.UK a adawsoch ar agor ar eich cyfrifiadur neu dabled.</string>
+    <string name="handback_returntodesktopweb_body2_content_description">I orffen profi pwy ydych chi, mae angen i chi ddychwelyd i’r dudalen Gov dot UK a adawsoch ar agor ar eich cyfrifiadur neu dabled.</string>
 </resources>

--- a/features/handback/internal/src/main/res/values-cy/strings.xml
+++ b/features/handback/internal/src/main/res/values-cy/strings.xml
@@ -11,4 +11,8 @@
     <string name="handback_returntomobileweb_body2">Nawr gallwch orffen profi pwy ydych chi ar wefan GOV.UK.</string>
     <string name="handback_returntomobileweb_body2_content_description">Nawr gallwch orffen profi pwy ydych chi ar wefan Gov dot yoo kay.</string>
     <string name="handback_returntomobileweb_button">Parhau i wefan GOV.UK</string>
+
+    <string name="handback_returntodesktopweb_title">Ewch yn ôl i GOV.UK ar eich cyfrifiadur neu dabled</string>
+    <string name="handback_returntodesktopweb_body1">Rydych chi wedi cyflwyno’ch gwybodaeth yn llwyddiannus.</string>
+    <string name="handback_returntodesktopweb_body2">I orffen profi pwy ydych chi, mae angen i chi ddychwelyd i’r dudalen GOV.UK a adawsoch ar agor ar eich cyfrifiadur neu dabled.</string>
 </resources>

--- a/features/handback/internal/src/main/res/values-cy/strings.xml
+++ b/features/handback/internal/src/main/res/values-cy/strings.xml
@@ -13,8 +13,8 @@
     <string name="handback_returntomobileweb_button">Parhau i wefan GOV.UK</string>
 
     <string name="handback_returntodesktopweb_title">Ewch yn ôl i GOV.UK ar eich cyfrifiadur neu dabled</string>
-    <string name="handback_returntodesktopweb_title_content_description">Ewch yn ôl i Gov dot UK ar eich cyfrifiadur neu dabled</string>
+    <string name="handback_returntodesktopweb_title_content_description">Ewch yn ôl i Gov dot yoo kay ar eich cyfrifiadur neu dabled</string>
     <string name="handback_returntodesktopweb_body1">Rydych chi wedi cyflwyno’ch gwybodaeth yn llwyddiannus.</string>
     <string name="handback_returntodesktopweb_body2">I orffen profi pwy ydych chi, mae angen i chi ddychwelyd i’r dudalen GOV.UK a adawsoch ar agor ar eich cyfrifiadur neu dabled.</string>
-    <string name="handback_returntodesktopweb_body2_content_description">I orffen profi pwy ydych chi, mae angen i chi ddychwelyd i’r dudalen Gov dot UK a adawsoch ar agor ar eich cyfrifiadur neu dabled.</string>
+    <string name="handback_returntodesktopweb_body2_content_description">I orffen profi pwy ydych chi, mae angen i chi ddychwelyd i’r dudalen Gov dot yoo kay a adawsoch ar agor ar eich cyfrifiadur neu dabled.</string>
 </resources>

--- a/features/handback/internal/src/main/res/values/strings.xml
+++ b/features/handback/internal/src/main/res/values/strings.xml
@@ -11,4 +11,8 @@
     <string name="handback_returntomobileweb_body2">You can now finish proving your identity on the GOV.UK website.</string>
     <string name="handback_returntomobileweb_body2_content_description">You can now finish proving your identity on the Gov dot UK website.</string>
     <string name="handback_returntomobileweb_button">Continue to the GOV.UK website</string>
+
+    <string name="handback_returntodesktopweb_title">Return to GOV.UK on your computer or tablet</string>
+    <string name="handback_returntodesktopweb_body1">You’ve successfully submitted your information.</string>
+    <string name="handback_returntodesktopweb_body2">To finish proving your identity, you need to return to the GOV.UK page you left open on your computer or tablet.</string>
 </resources>

--- a/features/handback/internal/src/main/res/values/strings.xml
+++ b/features/handback/internal/src/main/res/values/strings.xml
@@ -13,6 +13,8 @@
     <string name="handback_returntomobileweb_button">Continue to the GOV.UK website</string>
 
     <string name="handback_returntodesktopweb_title">Return to GOV.UK on your computer or tablet</string>
+    <string name="handback_returntodesktopweb_title_content_description">Return to Gov dot UK on your computer or tablet</string>
     <string name="handback_returntodesktopweb_body1">You’ve successfully submitted your information.</string>
     <string name="handback_returntodesktopweb_body2">To finish proving your identity, you need to return to the GOV.UK page you left open on your computer or tablet.</string>
+    <string name="handback_returntodesktopweb_body2_content_description">To finish proving your identity, you need to return to the Gov dot UK page you left open on your computer or tablet.</string>
 </resources>

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/analytics/HandbackScreenIdTest.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/analytics/HandbackScreenIdTest.kt
@@ -6,7 +6,8 @@ import org.junit.jupiter.api.Test
 class HandbackScreenIdTest {
     @Test
     fun `when screens are displayed, the IDs are set correctly`() {
-        assertEquals(HandbackScreenId.UnrecoverableError.rawId, "80069598-8c97-4789-96f8-8930fb633889")
-        assertEquals(HandbackScreenId.ReturnToMobileWeb.rawId, "4a9fafaa-5359-4105-b223-a51d71df435f")
+        assertEquals("80069598-8c97-4789-96f8-8930fb633889", HandbackScreenId.UnrecoverableError.rawId)
+        assertEquals("fff9c5fe-3eb2-45d4-a07a-fb6d21582c50", HandbackScreenId.ReturnToDesktopWeb.rawId)
+        assertEquals("4a9fafaa-5359-4105-b223-a51d71df435f", HandbackScreenId.ReturnToMobileWeb.rawId)
     }
 }

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreenAnalyticsTest.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreenAnalyticsTest.kt
@@ -1,0 +1,64 @@
+package uk.gov.onelogin.criorchestrator.features.handback.internal.returntodesktopweb
+
+import android.content.Context
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import uk.gov.logging.api.v3dot1.logger.asLegacyEvent
+import uk.gov.logging.api.v3dot1.model.ViewEvent
+import uk.gov.onelogin.criorchestrator.features.handback.internal.analytics.HandbackAnalytics
+import uk.gov.onelogin.criorchestrator.features.handback.internal.analytics.HandbackScreenId
+import uk.gov.onelogin.criorchestrator.libraries.analytics.resources.AndroidResourceProvider
+import uk.gov.onelogin.criorchestrator.libraries.testing.ReportingAnalyticsLoggerRule
+import kotlin.test.assertContains
+
+@RunWith(AndroidJUnit4::class)
+class ReturnToDesktopWebScreenAnalyticsTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val reportingAnalyticsLoggerRule = ReportingAnalyticsLoggerRule()
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val analyticsLogger = reportingAnalyticsLoggerRule.analyticsLogger
+
+    private val analytics =
+        HandbackAnalytics(
+            resourceProvider =
+                AndroidResourceProvider(
+                    context = context,
+                ),
+            analyticsLogger = analyticsLogger,
+        )
+
+    private val viewModel =
+        ReturnToDesktopWebViewModel(
+            analytics = analytics,
+        )
+
+    @Before
+    fun setup() {
+        composeTestRule.setContent {
+            ReturnToDesktopWebScreen(
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    @Test
+    fun `when screen starts, it tracks analytics`() {
+        val expectedEvent =
+            ViewEvent
+                .Screen(
+                    id = HandbackScreenId.ReturnToDesktopWeb.rawId,
+                    name = context.getString(ReturnToDesktopWebConstants.titleId),
+                    params = HandbackAnalytics.requiredParameters,
+                ).asLegacyEvent()
+
+        assertContains(analyticsLogger.loggedEvents, expectedEvent)
+    }
+}

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreenTest.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreenTest.kt
@@ -1,0 +1,48 @@
+package uk.gov.onelogin.criorchestrator.features.handback.internal.returntodesktopweb
+
+import android.content.Context
+import androidx.compose.ui.test.assertContentDescriptionContains
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import uk.gov.onelogin.criorchestrator.features.handback.internal.R
+
+@RunWith(AndroidJUnit4::class)
+class ReturnToDesktopWebScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val viewModel =
+        ReturnToDesktopWebViewModel(
+            analytics = mock(),
+        )
+
+    @Before
+    fun setup() {
+        composeTestRule.setContent {
+            ReturnToDesktopWebScreen(
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    @Test
+    fun `when talkback is enabled, it reads out Gov dot UK correctly`() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val title =
+            composeTestRule
+                .onNode(hasText(context.getString(ReturnToDesktopWebConstants.titleId)))
+        title.assertContentDescriptionContains("Gov dot UK", true)
+
+        val body =
+            composeTestRule
+                .onNode(hasText(context.getString(R.string.handback_returntodesktopweb_body2)))
+        body.assertContentDescriptionContains("Gov dot UK", true)
+    }
+}

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebViewModelTest.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebViewModelTest.kt
@@ -1,0 +1,27 @@
+package uk.gov.onelogin.criorchestrator.features.handback.internal.returntodesktopweb
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import uk.gov.onelogin.criorchestrator.features.handback.internal.analytics.HandbackAnalytics
+import uk.gov.onelogin.criorchestrator.features.handback.internal.analytics.HandbackScreenId
+
+class ReturnToDesktopWebViewModelTest {
+    private val analytics = mock<HandbackAnalytics>()
+
+    private val viewModel =
+        ReturnToDesktopWebViewModel(
+            analytics = analytics,
+        )
+
+    @Test
+    fun `when screen starts, it sends analytics`() {
+        viewModel.onScreenStart()
+
+        verify(analytics)
+            .trackScreen(
+                id = HandbackScreenId.ReturnToDesktopWeb,
+                title = ReturnToDesktopWebConstants.titleId,
+            )
+    }
+}

--- a/features/handback/internal/src/test/snapshots/images/features.handback.internal.returntodesktopweb_ReturnToDesktopWebScreenKt_PreviewReturnToMobileWebScreen_Dark_NIGHT.png
+++ b/features/handback/internal/src/test/snapshots/images/features.handback.internal.returntodesktopweb_ReturnToDesktopWebScreenKt_PreviewReturnToMobileWebScreen_Dark_NIGHT.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f606d23ca7350d5938db71ba09629d0ec1b027fc05c852a3a6bdaf2953918cc3
+size 33594

--- a/features/handback/internal/src/test/snapshots/images/features.handback.internal.returntodesktopweb_ReturnToDesktopWebScreenKt_PreviewReturnToMobileWebScreen_Light.png
+++ b/features/handback/internal/src/test/snapshots/images/features.handback.internal.returntodesktopweb_ReturnToDesktopWebScreenKt_PreviewReturnToMobileWebScreen_Light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a0b66a1341fe7d96b3240d67c1e32a653d63b0a3fd333a347f54aadf7a17ad3
+size 33455

--- a/features/handback/internal/src/test/snapshots/images/features.handback.internal.returntodesktopweb_ReturnToDesktopWebScreenKt_PreviewReturnToMobileWebScreen_cy.png
+++ b/features/handback/internal/src/test/snapshots/images/features.handback.internal.returntodesktopweb_ReturnToDesktopWebScreenKt_PreviewReturnToMobileWebScreen_cy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc81717d66dbfb5834929afe0d8365ca907c7f2c67b5a56cfa3ef89065d3b6c6
+size 38852


### PR DESCRIPTION
# DCMAW-11596: Create DAD handback Screen

## Evidence of the change

**AC1: User completes interaction with app**

> THEN i am routed to the ‘Return to [GOV.UK](http://gov.uk/) on your computer or tablet’ screen

✅ Already implemented and tested on the main branch in [SyncIdCheckScreenTest](https://github.com/govuk-one-login/mobile-android-cri-orchestrator/blob/e6bc9c29975591edb4fa728eecb4bbd3acd6f106/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenTest.kt#L97).

> AND the trackScreen analytics defined in the OpenAPI spec will be logged as an analytics event

✅ Covered by [ReturnToDesktopWebScreenAnalyticsTest](https://github.com/govuk-one-login/mobile-android-cri-orchestrator/blob/338fc84101edc1376221f845698c927f82ec52e4/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreenAnalyticsTest.kt#L53)

> AND the firebaseScreenId is set to fff9c5fe-3eb2-45d4-a07a-fb6d21582c50

✅ Covered by [ReturnToDesktopWebScreenAnalyticsTest](https://github.com/govuk-one-login/mobile-android-cri-orchestrator/blob/338fc84101edc1376221f845698c927f82ec52e4/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreenAnalyticsTest.kt#L53) and [HandbackScreenIdTest](https://github.com/govuk-one-login/mobile-android-cri-orchestrator/blob/338fc84101edc1376221f845698c927f82ec52e4/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/analytics/HandbackScreenIdTest.kt#L10)

**AC2: Welsh translation**

> THEN i can see the page as per design AND the text is in Welsh as per translation

✅ Covered by UI screenshot test:
![AC2 | Welsh Translation screenshot](https://media.githubusercontent.com/media/govuk-one-login/mobile-android-cri-orchestrator/d12e574cf05a61493eb67adf935b9901cd35a00e/features/handback/internal/src/test/snapshots/images/features.handback.internal.returntodesktopweb_ReturnToDesktopWebScreenKt_PreviewReturnToMobileWebScreen_cy.png)


**AC3: User selects X**

> THEN i am routed back to the home page 

✅ Already implemented and tested on the main branch in [ProveYourIdentityRootTest](https://github.com/govuk-one-login/mobile-android-cri-orchestrator/blob/920056cb2b5a194e48bc23909a25101e4c889741/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityRootTest.kt#L65)

> AND the trackEvent analytics defined above will be logged as an analytics event

⚠️ This is implemented in the main branch and covered by [ProveYourIdentityModalAnalyticsTest](https://github.com/govuk-one-login/mobile-android-cri-orchestrator/blob/920056cb2b5a194e48bc23909a25101e4c889741/features/resume/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityModalAnalyticsTest.kt#L54), *however the taxonomy value is send as "resume", rather than "handoff"*. This will likely require further discussion.

**AC4: User presses back**

> THEN i am routed back to the previous screen

This is default Android behaviour and therefore is not generally covered by automation tests.

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [x] Check against acceptance criteria
- [x] Add automated tests
- [x] Self-review code
