### PR TITLE
fix: Fix crash on launching ID Check SDK

### DIFF
--- a/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/android-lib-config.gradle.kts
+++ b/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/android-lib-config.gradle.kts
@@ -4,6 +4,7 @@ import com.android.build.api.dsl.LibraryExtension
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import uk.gov.onelogin.criorchestrator.extensions.androidTestDependencies
+import uk.gov.onelogin.criorchestrator.extensions.excludeAndroidClassesFromJacocoCoverage
 import uk.gov.onelogin.criorchestrator.extensions.disableJavadocGeneration
 import uk.gov.onelogin.criorchestrator.extensions.setInstrumentationTestingConfig
 import uk.gov.onelogin.criorchestrator.extensions.setJavaVersion
@@ -37,6 +38,9 @@ configure<KotlinAndroidProjectExtension> {
 // https://govukverify.atlassian.net/browse/DCMAW-11888
 // https://github.com/Kotlin/dokka/issues/2956
 project.disableJavadocGeneration()
+
+// https://github.com/cashapp/paparazzi/issues/955
+project.excludeAndroidClassesFromJacocoCoverage()
 
 dependencies {
     androidTestDependencies(libs)

--- a/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/extensions/Jacoco.kt
+++ b/build-logic/plugins/src/main/kotlin/uk/gov/onelogin/criorchestrator/extensions/Jacoco.kt
@@ -1,0 +1,22 @@
+package uk.gov.onelogin.criorchestrator.extensions
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.configure
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
+
+/**
+ * https://github.com/cashapp/paparazzi/issues/955
+ */
+fun Project.excludeAndroidClassesFromJacocoCoverage() {
+    tasks.withType<Test>(Test::class.java) {
+        extensions.configure<JacocoTaskExtension> {
+            excludes = excludes.orEmpty() +
+                    listOf(
+                        "androidx.core.*",
+                        "com.android.*",
+                        "android.*",
+                    )
+        }
+    }
+}

--- a/features/id-check-wrapper/internal/build.gradle.kts
+++ b/features/id-check-wrapper/internal/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("uk.gov.onelogin.criorchestrator.android-lib-config")
     id("uk.gov.onelogin.criorchestrator.ui-config")
     id("uk.gov.onelogin.criorchestrator.imposter-test-config")
+    id("uk.gov.onelogin.criorchestrator.id-check-sdk-compat-config")
     id("uk.gov.onelogin.criorchestrator.analytics-report")
     alias(libs.plugins.kotlin.serialization)
 }


### PR DESCRIPTION
## Changes

- Add configuration needed to launch ID Check SDK without crashing
- Fix incompatibility between Jacoco and Paparazzi when Android data binding is enabled

## Context

- Supercedes #322 

DCMAW-11490


## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [x] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
