### PR TITLE
build: update SDK version and align with backend mode

### DIFF
--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/activity/IdCheckSdkActivityParameters.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/activity/IdCheckSdkActivityParameters.kt
@@ -1,5 +1,6 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.activity
 
+import uk.gov.idcheck.repositories.api.webhandover.backend.BackendMode
 import uk.gov.idcheck.sdk.IdCheckSdkParameters
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.model.LauncherData
 
@@ -9,4 +10,5 @@ internal fun LauncherData.toIdCheckSdkActivityParameters() =
         journey = this.journeyType,
         sessionId = this.sessionId,
         bioToken = this.biometricToken,
+        backendMode = BackendMode.V2,
     )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ turbine = "1.2.0"
 uk-gov-logging = "0.21.5" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.7.2"
 uk-gov-ui = "7.25.1"
-gov-uk-idcheck = "0.9.0"
+gov-uk-idcheck = "0.11.0"
 
 [libraries]
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }

--- a/gradle/testwrapperlibs.versions.toml
+++ b/gradle/testwrapperlibs.versions.toml
@@ -6,7 +6,7 @@ dagger = "2.56.1"
 firebase-bom = "33.12.0" # https://firebase.google.com/support/release-notes/android
 firebase-crashlytics-gradle = "3.0.3" # https://firebase.google.com/support/release-notes/android
 google-services = "4.4.2" # https://developers.google.com/android/guides/releases
-gov-uk-idcheck = "0.9.0"
+gov-uk-idcheck = "0.11.0"
 
 [libraries]
 firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }

--- a/test-wrapper/build.gradle.kts
+++ b/test-wrapper/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation(projects.features.config.publicApi)
     implementation(projects.features.dev.publicApi)
     implementation(projects.sdk.publicApi)
-    implementation(projects.sdk.sharedApi)
     implementation(testwrapperlibs.firebase.analytics)
     implementation(testwrapperlibs.firebase.crashlytics)
     implementation(testwrapperlibs.hilt.android)


### PR DESCRIPTION
- Update SDK version to `0.11.0`
- Add backend mode to SDK launch parameters

## Evidence of the change
| Passport Light En MAM | BRP Light Cy MAM | Driving Licence Dark En MAM |
| -- | -- | -- |
| <video src="https://github.com/user-attachments/assets/e15ad60a-4ab7-44ce-97fa-3e8eba5e6055"> | <video src="https://github.com/user-attachments/assets/558a79a3-e31e-4ac4-b47b-d5d740ba2c7b"> | <video src="https://github.com/user-attachments/assets/70cb0153-fcfb-420e-8578-1d7afe5e19aa"> |

| Passport Light En DAD | BRP Dark Cy DAD |
| -- | -- |
| <video src="https://github.com/user-attachments/assets/651195da-f6ff-46c9-8b19-b4e82d3f34d6"> | <video src="https://github.com/user-attachments/assets/819021e3-8eee-4e9e-aff6-8c0b01ceb8bd"> | 
[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
