### PR TITLE
build: update SDK version to 0.11.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ turbine = "1.2.0"
 uk-gov-logging = "0.21.5" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.7.2"
 uk-gov-ui = "7.25.1"
-gov-uk-idcheck = "0.11.0"
+gov-uk-idcheck = "0.11.1"
 
 [libraries]
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }

--- a/gradle/testwrapperlibs.versions.toml
+++ b/gradle/testwrapperlibs.versions.toml
@@ -6,7 +6,7 @@ dagger = "2.56.1"
 firebase-bom = "33.12.0" # https://firebase.google.com/support/release-notes/android
 firebase-crashlytics-gradle = "3.0.3" # https://firebase.google.com/support/release-notes/android
 google-services = "4.4.2" # https://developers.google.com/android/guides/releases
-gov-uk-idcheck = "0.11.0"
+gov-uk-idcheck = "0.11.1"
 
 [libraries]
 firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }


### PR DESCRIPTION
- fixes `build` journeys

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change
https://github.com/govuk-one-login/mobile-id-check-android-sdk/pull/251#issue-3047192906

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
