### PR TITLE
fix: disable back button on handback screens

### DIFF
--- a/features/handback/internal/build.gradle.kts
+++ b/features/handback/internal/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
     implementation(projects.features.session.internalApi)
 
     testImplementation(testFixtures(projects.libraries.analytics))
+    testImplementation(testFixtures(projects.libraries.navigation))
+    testFixturesImplementation(testFixtures(projects.libraries.navigation))
     testImplementation(testFixtures(projects.features.session.internalApi))
     testImplementation(libs.uk.gov.logging.testdouble)
 }

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreen.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreen.kt
@@ -26,7 +26,7 @@ fun ReturnToDesktopWebScreen(
     viewModel: ReturnToDesktopWebViewModel,
     modifier: Modifier = Modifier,
 ) {
-    BackHandler(true) {
+    BackHandler(enabled = true) {
         // Back button should be disabled from this screen
         // as the user must return to their desktop browser
     }

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreen.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreen.kt
@@ -1,5 +1,6 @@
 package uk.gov.onelogin.criorchestrator.features.handback.internal.returntodesktopweb
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme.colorScheme
@@ -25,6 +26,11 @@ fun ReturnToDesktopWebScreen(
     viewModel: ReturnToDesktopWebViewModel,
     modifier: Modifier = Modifier,
 ) {
+    BackHandler(true) {
+        // Back button should be disabled from this screen
+        // as the user must return to their desktop browser
+    }
+
     ReturnToDesktopWebScreenContent(
         modifier = modifier,
     )

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreen.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreen.kt
@@ -37,7 +37,7 @@ fun ReturnToMobileWebScreen(
     webNavigator: WebNavigator,
     modifier: Modifier = Modifier,
 ) {
-    BackHandler(true) {
+    BackHandler(enabled = true) {
         // Back button should be disabled from this screen
         // as the user must return to their desktop browser
     }

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreen.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreen.kt
@@ -1,5 +1,6 @@
 package uk.gov.onelogin.criorchestrator.features.handback.internal.returntomobileweb
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonDefaults
@@ -36,6 +37,11 @@ fun ReturnToMobileWebScreen(
     webNavigator: WebNavigator,
     modifier: Modifier = Modifier,
 ) {
+    BackHandler(true) {
+        // Back button should be disabled from this screen
+        // as the user must return to their desktop browser
+    }
+
     ReturnToMobileWebScreenContent(
         onButtonClick = viewModel::onContinueToGovUk,
         modifier = modifier,

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/DisableBackButtonTest.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/DisableBackButtonTest.kt
@@ -11,17 +11,18 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import uk.gov.onelogin.criorchestrator.libraries.navigation.TestNavHost
 
 @RunWith(AndroidJUnit4::class)
 abstract class DisableBackButtonTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
-    private val originText = "Start destination"
+    private val originText = "Go to second screen"
 
     fun setContent(composable: @Composable () -> Unit) {
         composeTestRule.setContent {
-            TestNavigationHost(originText) {
+            TestNavHost(originText) {
                 composable()
             }
         }

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/DisableBackButtonTest.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/DisableBackButtonTest.kt
@@ -7,16 +7,21 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 abstract class DisableBackButtonTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
+    private val originText = "Start destination"
+
     fun setContent(composable: @Composable () -> Unit) {
         composeTestRule.setContent {
-            TestNavigationHost {
+            TestNavigationHost(originText) {
                 composable()
             }
         }
@@ -25,12 +30,12 @@ abstract class DisableBackButtonTest {
     @Test
     fun `when the back button is pressed, the user remains on this screen`() {
         composeTestRule
-            .onNode(hasText("Hello World"))
+            .onNode(hasText(originText))
             .assertIsDisplayed()
             .performClick()
 
         composeTestRule
-            .onNode(hasText("Hello World"))
+            .onNode(hasText(originText))
             .assertIsNotDisplayed()
 
         composeTestRule.activityRule.scenario.onActivity { activity ->
@@ -38,7 +43,7 @@ abstract class DisableBackButtonTest {
         }
 
         composeTestRule
-            .onNode(hasText("Hello World"))
+            .onNode(hasText(originText))
             .assertIsNotDisplayed()
     }
 }

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/DisableBackButtonTest.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/DisableBackButtonTest.kt
@@ -1,0 +1,44 @@
+package uk.gov.onelogin.criorchestrator.features.handback.internal
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+
+abstract class DisableBackButtonTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    fun setContent(composable: @Composable () -> Unit) {
+        composeTestRule.setContent {
+            TestNavigationHost {
+                composable()
+            }
+        }
+    }
+
+    @Test
+    fun `when the back button is pressed, the user remains on this screen`() {
+        composeTestRule
+            .onNode(hasText("Hello World"))
+            .assertIsDisplayed()
+            .performClick()
+
+        composeTestRule
+            .onNode(hasText("Hello World"))
+            .assertIsNotDisplayed()
+
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            activity.onBackPressedDispatcher.onBackPressed()
+        }
+
+        composeTestRule
+            .onNode(hasText("Hello World"))
+            .assertIsNotDisplayed()
+    }
+}

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/TestNavigationHost.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/TestNavigationHost.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.rememberNavController
 
 @Composable
 fun TestNavigationHost(
+    originText: String,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
@@ -27,7 +28,7 @@ fun TestNavigationHost(
                     navController.navigate("destination")
                 },
             ) {
-                Text("Hello World")
+                Text(originText)
             }
         }
 

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/TestNavigationHost.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/TestNavigationHost.kt
@@ -1,0 +1,38 @@
+package uk.gov.onelogin.criorchestrator.features.handback.internal
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+
+@Composable
+fun TestNavigationHost(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val navController = rememberNavController()
+    val startDestination = "origin"
+
+    NavHost(
+        navController,
+        startDestination = startDestination,
+        modifier = modifier,
+    ) {
+        composable("origin") {
+            Button(
+                onClick = {
+                    navController.navigate("destination")
+                },
+            ) {
+                Text("Hello World")
+            }
+        }
+
+        composable("destination") {
+            content()
+        }
+    }
+}

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreenDisableBackButtonTest.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreenDisableBackButtonTest.kt
@@ -1,0 +1,24 @@
+package uk.gov.onelogin.criorchestrator.features.handback.internal.returntodesktopweb
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import uk.gov.onelogin.criorchestrator.features.handback.internal.DisableBackButtonTest
+
+@RunWith(AndroidJUnit4::class)
+class ReturnToDesktopWebScreenDisableBackButtonTest : DisableBackButtonTest() {
+    private val viewModel =
+        ReturnToDesktopWebViewModel(
+            analytics = mock(),
+        )
+
+    @Before
+    fun setup() {
+        setContent {
+            ReturnToDesktopWebScreen(
+                viewModel = viewModel,
+            )
+        }
+    }
+}

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreenDisableBackButtonTest.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreenDisableBackButtonTest.kt
@@ -1,0 +1,38 @@
+package uk.gov.onelogin.criorchestrator.features.handback.internal.returntomobileweb
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import uk.gov.onelogin.criorchestrator.features.handback.internal.DisableBackButtonTest
+import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.FakeSessionStore
+import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.Session
+import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.createTestInstance
+
+@RunWith(AndroidJUnit4::class)
+class ReturnToMobileWebScreenDisableBackButtonTest : DisableBackButtonTest() {
+    private val session =
+        Session.createTestInstance(
+            redirectUri = REDIRECT_URI,
+        )
+    private val viewModel =
+        ReturnToMobileWebViewModel(
+            analytics = mock(),
+            sessionStore =
+                FakeSessionStore(
+                    session = session,
+                ),
+        )
+
+    private val webNavigator = FakeWebNavigator()
+
+    @Before
+    fun setup() {
+        setContent {
+            ReturnToMobileWebScreen(
+                viewModel = viewModel,
+                webNavigator = webNavigator,
+            )
+        }
+    }
+}

--- a/libraries/navigation/build.gradle.kts
+++ b/libraries/navigation/build.gradle.kts
@@ -12,4 +12,6 @@ dependencies {
 
     testImplementation(libs.androidx.compose.material3)
     testImplementation(libs.kotlinx.serialization.json)
+
+    testFixturesImplementation(libs.androidx.compose.material3)
 }

--- a/libraries/navigation/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/libraries/navigation/TestNavHost.kt
+++ b/libraries/navigation/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/libraries/navigation/TestNavHost.kt
@@ -1,4 +1,4 @@
-package uk.gov.onelogin.criorchestrator.features.handback.internal
+package uk.gov.onelogin.criorchestrator.libraries.navigation
 
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
@@ -9,7 +9,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 
 @Composable
-fun TestNavigationHost(
+fun TestNavHost(
     originText: String,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,


### PR DESCRIPTION
# Disable back button on handback screens

This meets the updated AC5 for these two screens.

## Evidence of the change

- DCMAW-11595

> AC5: Back button disabled
> GIVEN i am on the ‘Return to [GOV.UK](http://gov.uk/)’ screen
> THEN the back button is disabled

✅ [ReturnToMobileWebScreenDisableBackButtonTest.kt](https://github.com/govuk-one-login/mobile-android-cri-orchestrator/blob/083b4a99fb6764f8eef07e15055a5d3df69ab183/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreenDisableBackButtonTest.kt)

- DCMAW-11596

> AC5: Back button disabled
> GIVEN i am on the ‘Return to [GOV.UK](http://gov.uk/)’ screen
> THEN the back button is disabled

✅ [ReturnToDesktopWebScreenDisableBackButtonTest.kt](https://github.com/govuk-one-login/mobile-android-cri-orchestrator/blob/083b4a99fb6764f8eef07e15055a5d3df69ab183/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntodesktopweb/ReturnToDesktopWebScreenDisableBackButtonTest.kt)

## Checklist

- [x] Check against acceptance criteria
- [x] Add automated tests
- [x] Self-review code
