### PR TITLE
refactor: Reorganise active session API classes

### DIFF
--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReader.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReader.kt
@@ -1,4 +1,4 @@
-package uk.gov.onelogin.criorchestrator.features.session.internal.network
+package uk.gov.onelogin.criorchestrator.features.session.internal
 
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -6,7 +6,8 @@ import kotlinx.serialization.json.Json
 import uk.gov.android.network.api.ApiResponse
 import uk.gov.logging.api.LogTagProvider
 import uk.gov.logging.api.Logger
-import uk.gov.onelogin.criorchestrator.features.session.internal.network.response.ActiveSessionApiResponse
+import uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession.ActiveSessionApi
+import uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession.ActiveSessionApiResponse
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.Session
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionReader
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionStore
@@ -22,7 +23,7 @@ class RemoteSessionReader
     @Inject
     constructor(
         private val sessionStore: SessionStore,
-        private val sessionApi: Provider<SessionApi>,
+        private val activeSessionApi: Provider<ActiveSessionApi>,
         private val logger: Logger,
     ) : SessionReader,
         LogTagProvider {
@@ -33,7 +34,7 @@ class RemoteSessionReader
         }
 
         override suspend fun isActiveSession(): Boolean {
-            val response = sessionApi.get().getActiveSession()
+            val response = activeSessionApi.get().getActiveSession()
             logResponse(response)
             val session = parseSession(response)
             sessionStore.write(session)

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/data/InMemorySessionStore.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/data/InMemorySessionStore.kt
@@ -1,4 +1,4 @@
-package uk.gov.onelogin.criorchestrator.features.session.internal.network.data
+package uk.gov.onelogin.criorchestrator.features.session.internal.data
 
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/SessionApi.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/SessionApi.kt
@@ -1,7 +1,0 @@
-package uk.gov.onelogin.criorchestrator.features.session.internal.network
-
-import uk.gov.android.network.api.ApiResponse
-
-fun interface SessionApi {
-    suspend fun getActiveSession(): ApiResponse
-}

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApi.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApi.kt
@@ -1,0 +1,7 @@
+package uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession
+
+import uk.gov.android.network.api.ApiResponse
+
+fun interface ActiveSessionApi {
+    suspend fun getActiveSession(): ApiResponse
+}

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiImpl.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiImpl.kt
@@ -1,4 +1,4 @@
-package uk.gov.onelogin.criorchestrator.features.session.internal.network
+package uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession
 
 import kotlinx.coroutines.flow.first
 import uk.gov.android.network.api.ApiRequest
@@ -6,22 +6,22 @@ import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.logging.api.LogTagProvider
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
-import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey.IdCheckAsyncBackendBaseUrl
+import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
 import uk.gov.onelogin.criorchestrator.libraries.di.CompositionScope
 import javax.inject.Inject
 
 private const val GET_ACTIVE_SESSION_ENDPOINT = "/async/activeSession"
 
 @CompositionScope
-class SessionApiImpl
+class ActiveSessionApiImpl
     @Inject
     constructor(
         private val httpClient: GenericHttpClient,
         private val configStore: ConfigStore,
-    ) : SessionApi,
+    ) : ActiveSessionApi,
         LogTagProvider {
         override suspend fun getActiveSession(): ApiResponse {
-            val baseUrl = configStore.read(IdCheckAsyncBackendBaseUrl).first().value
+            val baseUrl = configStore.read(SdkConfigKey.IdCheckAsyncBackendBaseUrl).first().value
             val request =
                 ApiRequest.Get(
                     url = baseUrl + GET_ACTIVE_SESSION_ENDPOINT,

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiModule.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiModule.kt
@@ -1,4 +1,4 @@
-package uk.gov.onelogin.criorchestrator.features.session.internal.network
+package uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession
 
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -9,16 +9,16 @@ import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
 
 @Module
 @ContributesTo(CriOrchestratorScope::class)
-class SessionApiModule {
+class ActiveSessionApiModule {
     @Provides
-    fun providesSessionApi(
+    fun providesActiveSessionApi(
         config: ConfigStore,
-        realSessionApi: SessionApiImpl,
-        fakeSessionApi: FakeSessionApi,
-    ): SessionApi =
+        realActiveSessionApi: ActiveSessionApiImpl,
+        fakeActiveSessionApi: FakeActiveSessionApi,
+    ): ActiveSessionApi =
         if (config.readSingle(SdkConfigKey.BypassIdCheckAsyncBackend).value) {
-            fakeSessionApi
+            fakeActiveSessionApi
         } else {
-            realSessionApi
+            realActiveSessionApi
         }
 }

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiResponse.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiResponse.kt
@@ -1,4 +1,4 @@
-package uk.gov.onelogin.criorchestrator.features.session.internal.network.response
+package uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/FakeActiveSessionApi.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/FakeActiveSessionApi.kt
@@ -1,11 +1,11 @@
-package uk.gov.onelogin.criorchestrator.features.session.internal.network
+package uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession
 
 import uk.gov.android.network.api.ApiResponse
 import javax.inject.Inject
 
-class FakeSessionApi
+class FakeActiveSessionApi
     @Inject
-    constructor() : SessionApi {
+    constructor() : ActiveSessionApi {
         override suspend fun getActiveSession(): ApiResponse =
             ApiResponse.Success<String>(
                 """

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
@@ -12,10 +12,10 @@ import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.FakeConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
-import uk.gov.onelogin.criorchestrator.features.session.internal.network.RemoteSessionReader
-import uk.gov.onelogin.criorchestrator.features.session.internal.network.SessionApi
-import uk.gov.onelogin.criorchestrator.features.session.internal.network.SessionApiImpl
-import uk.gov.onelogin.criorchestrator.features.session.internal.network.data.InMemorySessionStore
+import uk.gov.onelogin.criorchestrator.features.session.internal.RemoteSessionReader
+import uk.gov.onelogin.criorchestrator.features.session.internal.data.InMemorySessionStore
+import uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession.ActiveSessionApi
+import uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession.ActiveSessionApiImpl
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.Session
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionStore
 import uk.gov.onelogin.criorchestrator.libraries.testing.networking.Imposter
@@ -28,7 +28,7 @@ class IntegrationTest {
     private val logger = SystemLogger()
     private val imposter = Imposter.createMockEngine()
 
-    private lateinit var sessionApi: SessionApi
+    private lateinit var activeSessionApi: ActiveSessionApi
     private lateinit var remoteSessionReader: RemoteSessionReader
     private lateinit var sessionStore: SessionStore
 
@@ -44,8 +44,8 @@ class IntegrationTest {
                     ),
             ),
         )
-        sessionApi =
-            SessionApiImpl(
+        activeSessionApi =
+            ActiveSessionApiImpl(
                 httpClient = createTestHttpClient(),
                 configStore = fakeConfigStore,
             )
@@ -53,7 +53,7 @@ class IntegrationTest {
         remoteSessionReader =
             RemoteSessionReader(
                 sessionStore = sessionStore,
-                sessionApi = Provider { sessionApi },
+                activeSessionApi = Provider { activeSessionApi },
                 logger = logger,
             )
     }

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
@@ -17,8 +17,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import uk.gov.android.network.api.ApiResponse
 import uk.gov.logging.testdouble.SystemLogger
-import uk.gov.onelogin.criorchestrator.features.session.internal.network.RemoteSessionReader
-import uk.gov.onelogin.criorchestrator.features.session.internal.network.data.InMemorySessionStore
+import uk.gov.onelogin.criorchestrator.features.session.internal.data.InMemorySessionStore
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionReader
 import java.util.stream.Stream
 import javax.inject.Provider
@@ -26,7 +25,7 @@ import javax.inject.Provider
 @ExperimentalCoroutinesApi
 class RemoteSessionReaderTest {
     private val logger = SystemLogger()
-    private val sessionApi = spy(StubSessionApiImpl())
+    private val activeSessionApi = spy(StubActiveSessionApiImpl())
 
     private lateinit var remoteSessionReader: SessionReader
 
@@ -35,14 +34,14 @@ class RemoteSessionReaderTest {
         remoteSessionReader =
             RemoteSessionReader(
                 sessionStore = InMemorySessionStore(logger),
-                sessionApi = Provider { sessionApi },
+                activeSessionApi = Provider { activeSessionApi },
                 logger = logger,
             )
     }
 
     @AfterEach
     fun tearDown() {
-        sessionApi.setActiveSession(ApiResponse.Offline)
+        activeSessionApi.setActiveSession(ApiResponse.Offline)
     }
 
     @ParameterizedTest(name = "{0}")
@@ -52,7 +51,7 @@ class RemoteSessionReaderTest {
         logEntry: String,
         expectedIsActiveSession: Boolean,
     ) = runTest {
-        sessionApi.setActiveSession(apiResponse)
+        activeSessionApi.setActiveSession(apiResponse)
         val isActiveSession = remoteSessionReader.isActiveSession()
         assertEquals(expectedIsActiveSession, isActiveSession)
         assertTrue(logger.contains(logEntry))
@@ -62,7 +61,7 @@ class RemoteSessionReaderTest {
     fun `session API is called just once`() =
         runTest {
             remoteSessionReader.isActiveSession()
-            verify(sessionApi, times(1)).getActiveSession()
+            verify(activeSessionApi, times(1)).getActiveSession()
         }
 
     companion object {

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/data/InMemorySessionStoreTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/data/InMemorySessionStoreTest.kt
@@ -3,7 +3,6 @@ package uk.gov.onelogin.criorchestrator.features.session.internal.data
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import uk.gov.logging.testdouble.SystemLogger
-import uk.gov.onelogin.criorchestrator.features.session.internal.network.data.InMemorySessionStore
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.Session
 
 class InMemorySessionStoreTest {

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiImplTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiImplTest.kt
@@ -1,8 +1,8 @@
-package uk.gov.onelogin.criorchestrator.features.session.internal.network
+package uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.android.network.api.ApiResponse
@@ -13,10 +13,10 @@ import uk.gov.onelogin.criorchestrator.libraries.testing.networking.Imposter
 import uk.gov.onelogin.criorchestrator.libraries.testing.networking.createTestHttpClient
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class SessionApiImplTest {
+class ActiveSessionApiImplTest {
     private val fakeConfigStore = FakeConfigStore()
 
-    private lateinit var sessionApiImpl: SessionApi
+    private lateinit var activeSessionApiImpl: ActiveSessionApi
 
     @BeforeEach
     fun setup() {
@@ -30,8 +30,8 @@ class SessionApiImplTest {
                     ),
             ),
         )
-        sessionApiImpl =
-            SessionApiImpl(
+        activeSessionApiImpl =
+            ActiveSessionApiImpl(
                 httpClient = createTestHttpClient(),
                 configStore = fakeConfigStore,
             )
@@ -47,7 +47,7 @@ class SessionApiImplTest {
                         "\"state\":\"11112222333344445555666677778888\"}",
                 )
 
-            val result = sessionApiImpl.getActiveSession()
-            assertEquals(expected, result)
+            val result = activeSessionApiImpl.getActiveSession()
+            Assertions.assertEquals(expected, result)
         }
 }

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/FakeSessionApiTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/FakeSessionApiTest.kt
@@ -1,16 +1,15 @@
-package uk.gov.onelogin.criorchestrator.features.session.internal
+package uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession
 
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import uk.gov.android.network.api.ApiResponse
-import uk.gov.onelogin.criorchestrator.features.session.internal.network.FakeSessionApi
 
 class FakeSessionApiTest {
     @Test
     fun `verify fake session API returns intended response`() =
         runTest {
-            assertEquals(
+            Assertions.assertEquals(
                 ApiResponse.Success<String>(
                     """
                     {
@@ -20,7 +19,7 @@ class FakeSessionApiTest {
                     }
                     """.trimIndent(),
                 ),
-                FakeSessionApi().getActiveSession(),
+                FakeActiveSessionApi().getActiveSession(),
             )
         }
 }

--- a/features/session/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/StubActiveSessionApiImpl.kt
+++ b/features/session/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/StubActiveSessionApiImpl.kt
@@ -1,9 +1,9 @@
 package uk.gov.onelogin.criorchestrator.features.session.internal
 
 import uk.gov.android.network.api.ApiResponse
-import uk.gov.onelogin.criorchestrator.features.session.internal.network.SessionApi
+import uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession.ActiveSessionApi
 
-class StubSessionApiImpl : SessionApi {
+class StubActiveSessionApiImpl : ActiveSessionApi {
     private var returnedResponse: ApiResponse = ApiResponse.Offline
 
     fun setActiveSession(response: ApiResponse) {


### PR DESCRIPTION
## Changes

- Reorganise active session API classes
- Rename `SessionApi` to `ActiveSessionApi`

## Context

DCMAW-11981

Makes way for a second API call to be added to the `network` package within `features:session:internal`. The packages would then be:

- `uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession`
- `uk.gov.onelogin.criorchestrator.features.session.internal.network.abort`

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
