### PR TITLE
fix: Prevent double navigation when double clicking navigation button

### DIFF
--- a/features/error/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/error/internal/recoverableerror/RecoverableErrorScreen.kt
+++ b/features/error/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/error/internal/recoverableerror/RecoverableErrorScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import kotlinx.collections.immutable.persistentListOf
 import uk.gov.android.ui.patterns.centrealignedscreen.CentreAlignedScreenBodyContent
@@ -70,7 +71,7 @@ internal fun RecoverableErrorScreenContent(
             primaryButton =
                 CentreAlignedScreenButton(
                     text = stringResource(RecoverableErrorConstants.buttonTextId),
-                    onClick = onButtonClick,
+                    onClick = dropUnlessResumed { onButtonClick() },
                 ),
         )
     }

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreen.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.compose.dropUnlessResumed
 import uk.gov.android.ui.componentsv2.R.drawable.ic_external_site
 import uk.gov.android.ui.componentsv2.R.string.opens_in_external_browser
 import uk.gov.android.ui.componentsv2.button.ButtonType
@@ -126,7 +127,7 @@ private fun ReturnToMobileWebScreenContent(
                             iconImage = ImageVector.vectorResource(ic_external_site),
                             contentDescription = stringResource(opens_in_external_browser),
                         ),
-                    onClick = onButtonClick,
+                    onClick = dropUnlessResumed { onButtonClick() },
                     modifier = Modifier.fillMaxWidth(),
                 )
             },

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/unrecoverableerror/UnrecoverableErrorScreen.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/unrecoverableerror/UnrecoverableErrorScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import kotlinx.collections.immutable.persistentListOf
 import uk.gov.android.ui.patterns.centrealignedscreen.CentreAlignedScreenBodyContent
@@ -71,7 +72,7 @@ internal fun UnrecoverableErrorScreenContent(
             secondaryButton =
                 CentreAlignedScreenButton(
                     text = stringResource(UnrecoverableErrorConstants.buttonTextId),
-                    onClick = onButtonClick,
+                    onClick = dropUnlessResumed { onButtonClick() },
                 ),
         )
     }

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenManualLauncherContent.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenManualLauncherContent.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.dropUnlessResumed
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import uk.gov.android.ui.componentsv2.button.ButtonType
@@ -77,7 +78,7 @@ internal fun SyncIdCheckScreenManualLauncherContent(
         primaryButton = {
             GdsButton(
                 text = "Launch ID Check SDK",
-                onClick = onLaunchRequest,
+                onClick = dropUnlessResumed { onLaunchRequest() },
                 buttonType = ButtonType.Primary,
                 modifier = Modifier.fillMaxWidth(),
             )

--- a/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/card/ProveYourIdentityUiCard.kt
+++ b/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/card/ProveYourIdentityUiCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.lifecycle.compose.dropUnlessResumed
 import uk.gov.android.ui.componentsv2.GdsCard
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.onelogin.criorchestrator.features.resume.internal.R
@@ -19,7 +20,7 @@ internal fun ProveYourIdentityUiCard(
         body = stringResource(R.string.start_id_check_content),
         buttonText = stringResource(R.string.start_id_check_primary_button),
         modifier = modifier,
-        onClick = onStartClick,
+        onClick = dropUnlessResumed { onStartClick() },
     )
 }
 

--- a/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/screen/ContinueToProveYourIdentityScreen.kt
+++ b/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/screen/ContinueToProveYourIdentityScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import kotlinx.collections.immutable.persistentListOf
 import uk.gov.android.ui.patterns.centrealignedscreen.CentreAlignedScreen
@@ -63,7 +64,7 @@ internal fun ContinueToProveYourIdentityContent(
     primaryButton =
         CentreAlignedScreenButton(
             text = stringResource(R.string.continue_to_prove_your_identity_screen_button),
-            onClick = onContinueClick,
+            onClick = dropUnlessResumed { onContinueClick() },
         ),
 )
 

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/brp/confirm/ConfirmBrpScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/brp/confirm/ConfirmBrpScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import uk.gov.android.ui.componentsv2.button.ButtonType
 import uk.gov.android.ui.componentsv2.button.GdsButton
@@ -108,7 +109,7 @@ internal fun ConfirmBrpScreenContent(
                 GdsButton(
                     text = confirmButtonText,
                     buttonType = ButtonType.Primary,
-                    onClick = onPrimaryClick,
+                    onClick = dropUnlessResumed { onPrimaryClick() },
                     modifier = Modifier.fillMaxWidth(),
                 )
             },

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/brp/select/SelectBrpScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/brp/select/SelectBrpScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
@@ -126,7 +127,7 @@ internal fun SelectBrpScreenContent(
                 GdsButton(
                     text = stringResource(SelectBrpConstants.readMoreButtonTextId),
                     buttonType = ButtonType.Secondary,
-                    onClick = onReadMoreClicked,
+                    onClick = dropUnlessResumed { onReadMoreClicked() },
                     modifier = Modifier.padding(horizontal = horizontalPadding),
                     textAlign = TextAlign.Start,
                     contentPosition = Arrangement.Start,
@@ -154,11 +155,12 @@ internal fun SelectBrpScreenContent(
             GdsButton(
                 stringResource(SelectBrpConstants.continueButtonTextId),
                 buttonType = ButtonType.Primary,
-                onClick = {
-                    selectedItem?.let {
-                        onContinueClicked(it)
-                    }
-                },
+                onClick =
+                    dropUnlessResumed {
+                        selectedItem?.let {
+                            onContinueClicked(it)
+                        }
+                    },
                 enabled = selectedItem != null,
                 modifier = Modifier.fillMaxWidth(),
             )

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/confirmnoid/nochippedid/ConfirmNoChippedIDScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/confirmnoid/nochippedid/ConfirmNoChippedIDScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import kotlinx.collections.immutable.persistentListOf
 import uk.gov.android.ui.componentsv2.button.ButtonType
@@ -107,7 +108,7 @@ internal fun ConfirmNoChippedIDContent(
                 GdsButton(
                     stringResource(ConfirmNoChippedIDConstants.confirmButtonTextId),
                     buttonType = ButtonType.Primary,
-                    onClick = onConfirmClick,
+                    onClick = dropUnlessResumed { onConfirmClick() },
                     modifier = Modifier.fillMaxWidth(),
                 )
             },

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/confirmnoid/nononchippedid/ConfirmNoNonChippedIDScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/confirmnoid/nononchippedid/ConfirmNoNonChippedIDScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import kotlinx.collections.immutable.persistentListOf
 import uk.gov.android.ui.componentsv2.button.ButtonType
@@ -100,7 +101,7 @@ internal fun ConfirmNoNonChippedIDContent(
                 GdsButton(
                     stringResource(ConfirmNoNonChippedIDConstants.confirmButtonTextId),
                     buttonType = ButtonType.Primary,
-                    onClick = onConfirmClick,
+                    onClick = dropUnlessResumed { onConfirmClick() },
                     modifier = Modifier.fillMaxWidth(),
                 )
             },

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/drivinglicence/confirm/ConfirmDrivingLicenceScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/drivinglicence/confirm/ConfirmDrivingLicenceScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import uk.gov.android.ui.componentsv2.button.ButtonType
 import uk.gov.android.ui.componentsv2.button.GdsButton
@@ -101,7 +102,7 @@ internal fun ConfirmDrivingLicenceScreenContent(
                 GdsButton(
                     text = confirmButtonText,
                     buttonType = ButtonType.Primary,
-                    onClick = onPrimaryClick,
+                    onClick = dropUnlessResumed { onPrimaryClick() },
                     modifier = Modifier.fillMaxWidth(),
                 )
             },

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/drivinglicence/select/SelectDrivingLicenceScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/drivinglicence/select/SelectDrivingLicenceScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import kotlinx.collections.immutable.toPersistentList
 import uk.gov.android.ui.componentsv2.button.ButtonType
@@ -116,7 +117,7 @@ internal fun SelectDrivingLicenceScreenContent(
                         GdsButton(
                             text = stringResource(SelectDrivingLicenceConstants.readMoreButtonTextId),
                             buttonType = ButtonType.Secondary,
-                            onClick = onReadMoreClick,
+                            onClick = dropUnlessResumed { onReadMoreClick() },
                             modifier = Modifier.padding(horizontal = horizontalPadding),
                             contentModifier = Modifier,
                             textAlign = TextAlign.Left,

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/confirm/ConfirmPassportScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/confirm/ConfirmPassportScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import uk.gov.android.ui.componentsv2.button.ButtonType
 import uk.gov.android.ui.componentsv2.button.GdsButton
@@ -101,7 +102,7 @@ internal fun ConfirmPassportScreenContent(
                 GdsButton(
                     text = confirmButtonText,
                     buttonType = ButtonType.Primary,
-                    onClick = onPrimaryClick,
+                    onClick = dropUnlessResumed { onPrimaryClick() },
                     modifier = Modifier.fillMaxWidth(),
                 )
             },

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/select/SelectPassportScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/select/SelectPassportScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import kotlinx.collections.immutable.toPersistentList
 import uk.gov.android.ui.componentsv2.button.ButtonType
@@ -115,7 +116,7 @@ internal fun SelectPassportScreenContent(
                     GdsButton(
                         text = stringResource(SelectPassportConstants.readMoreButtonTextId),
                         buttonType = ButtonType.Secondary,
-                        onClick = onReadMoreClick,
+                        onClick = dropUnlessResumed { onReadMoreClick() },
                         modifier = Modifier.padding(horizontal = horizontalPadding),
                         contentModifier = Modifier,
                         textAlign = TextAlign.Left,
@@ -144,11 +145,12 @@ internal fun SelectPassportScreenContent(
                 GdsButton(
                     text = stringResource(SelectPassportConstants.buttonTextId),
                     buttonType = ButtonType.Primary,
-                    onClick = {
-                        selectedItem?.let {
-                            onConfirmSelection(it)
-                        }
-                    },
+                    onClick =
+                        dropUnlessResumed {
+                            selectedItem?.let {
+                                onConfirmSelection(it)
+                            }
+                        },
                     enabled = selectedItem != null,
                     modifier = Modifier.fillMaxWidth(),
                 )


### PR DESCRIPTION
## Changes

Ignore button presses that trigger navigation once navigation has been triggered.

## Context

Currently, rapidly double pressing a button that triggers navigation will result in a double navigation.

Android lifecycle provides a mechanism designed to guard against this, which this PR introduces:

> this can be used with Navigation Compose to avoid handling click events after a transition to another screen has already begun: onClick: () -> Unit = dropUnlessResumed { navController.navigate(NEW_SCREEN) }

– https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.0

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
