### PR TITLE
feat: Add abort session API result config option

### DIFF
--- a/features/config/public-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/config/publicapi/SdkConfigKey.kt
+++ b/features/config/public-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/config/publicapi/SdkConfigKey.kt
@@ -41,4 +41,21 @@ sealed interface SdkConfigKey {
         const val OPTION_MOBILE_APP_MOBILE = "Mobile-app-mobile (MAM)"
         const val OPTION_DESKTOP_APP_DESKTOP = "Desktop-app-desktop (DAD)"
     }
+
+    data object BypassAbortSessionApiCall :
+        OptionConfigKey(
+            name = "Abort session API",
+            options =
+                listOf(
+                    BypassAbortSessionApiCall.OPTION_SUCCESS,
+                    BypassAbortSessionApiCall.OPTION_OFFLINE,
+                    BypassAbortSessionApiCall.OPTION_UNRECOVERABLE_ERROR,
+                ).toPersistentList(),
+            dependsOn = BypassIdCheckAsyncBackend,
+        ),
+        SdkConfigKey {
+        const val OPTION_SUCCESS = "Success"
+        const val OPTION_OFFLINE = "Offline error"
+        const val OPTION_UNRECOVERABLE_ERROR = "Unrecoverable error"
+    }
 }

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/FakeAbortSessionApi.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/FakeAbortSessionApi.kt
@@ -1,10 +1,27 @@
 package uk.gov.onelogin.criorchestrator.features.session.internal.network.abort
 
 import uk.gov.android.network.api.ApiResponse
+import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
+import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
 import javax.inject.Inject
+
+private const val BAD_REQUEST = 400
 
 class FakeAbortSessionApi
     @Inject
-    constructor() : AbortSessionApi {
-        override suspend fun abortSession(sessionId: String): ApiResponse = ApiResponse.Success<String>("")
+    constructor(
+        private val configStore: ConfigStore,
+    ) : AbortSessionApi {
+        override suspend fun abortSession(sessionId: String): ApiResponse =
+            when (configStore.readSingle(SdkConfigKey.BypassAbortSessionApiCall).value) {
+                SdkConfigKey.BypassAbortSessionApiCall.OPTION_SUCCESS -> ApiResponse.Success<String>("")
+                SdkConfigKey.BypassAbortSessionApiCall.OPTION_OFFLINE -> ApiResponse.Offline
+                SdkConfigKey.BypassAbortSessionApiCall.OPTION_UNRECOVERABLE_ERROR ->
+                    ApiResponse.Failure(
+                        BAD_REQUEST,
+                        Exception("Simulated exception"),
+                    )
+
+                else -> error("Unknown bypass abort session API call result configuration")
+            }
     }

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/FakeAbortSessionApiTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/FakeAbortSessionApiTest.kt
@@ -4,13 +4,68 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import uk.gov.android.network.api.ApiResponse
+import uk.gov.onelogin.criorchestrator.features.config.internalapi.FakeConfigStore
+import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
+import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
 
 class FakeAbortSessionApiTest {
+    val configStore = FakeConfigStore()
+    val fakeApi =
+        FakeAbortSessionApi(
+            configStore = configStore,
+        )
+
     @Test
-    fun `it returns success`() =
+    fun `given config is success, it returns success`() =
         runTest {
-            val fakeApi = FakeAbortSessionApi()
+            configStore.write(
+                entry =
+                    Config.Entry<Config.Value.StringValue>(
+                        key = SdkConfigKey.BypassAbortSessionApiCall,
+                        value =
+                            Config.Value.StringValue(
+                                SdkConfigKey.BypassAbortSessionApiCall.OPTION_SUCCESS,
+                            ),
+                    ),
+            )
             val result = fakeApi.abortSession("sessionId")
             assertEquals(ApiResponse.Success(""), result)
+        }
+
+    @Test
+    fun `given config is offline, it returns offline`() =
+        runTest {
+            configStore.write(
+                entry =
+                    Config.Entry<Config.Value.StringValue>(
+                        key = SdkConfigKey.BypassAbortSessionApiCall,
+                        value =
+                            Config.Value.StringValue(
+                                SdkConfigKey.BypassAbortSessionApiCall.OPTION_OFFLINE,
+                            ),
+                    ),
+            )
+            val result = fakeApi.abortSession("sessionId")
+            assertEquals(ApiResponse.Offline, result)
+        }
+
+    @Test
+    fun `given config is unrecoverable error, it returns unrecoverable error`() =
+        runTest {
+            configStore.write(
+                entry =
+                    Config.Entry<Config.Value.StringValue>(
+                        key = SdkConfigKey.BypassAbortSessionApiCall,
+                        value =
+                            Config.Value.StringValue(
+                                SdkConfigKey.BypassAbortSessionApiCall.OPTION_UNRECOVERABLE_ERROR,
+                            ),
+                    ),
+            )
+            val result = fakeApi.abortSession("sessionId")
+            assertEquals(
+                "Simulated exception",
+                (result as ApiResponse.Failure).error.message,
+            )
         }
 }

--- a/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/config/DefaultConfig.kt
+++ b/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/config/DefaultConfig.kt
@@ -17,6 +17,10 @@ private val defaultConfig =
                     key = SdkConfigKey.BypassJourneyType,
                     Config.Value.StringValue(SdkConfigKey.BypassJourneyType.OPTION_MOBILE_APP_MOBILE),
                 ),
+                Config.Entry<Config.Value.StringValue>(
+                    key = SdkConfigKey.BypassAbortSessionApiCall,
+                    Config.Value.StringValue(SdkConfigKey.BypassAbortSessionApiCall.OPTION_SUCCESS),
+                ),
                 Config.Entry<Config.Value.BooleanValue>(
                     key = IdCheckWrapperConfigKey.EnableManualLauncher,
                     Config.Value.BooleanValue(false),

--- a/sdk/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/CriOrchestratorSingletonImplTest.kt
+++ b/sdk/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/CriOrchestratorSingletonImplTest.kt
@@ -54,6 +54,10 @@ class CriOrchestratorSingletonImplTest {
                                 key = SdkConfigKey.BypassJourneyType,
                                 Config.Value.StringValue(SdkConfigKey.BypassJourneyType.OPTION_MOBILE_APP_MOBILE),
                             ),
+                            Config.Entry<Config.Value.StringValue>(
+                                key = SdkConfigKey.BypassAbortSessionApiCall,
+                                Config.Value.StringValue(SdkConfigKey.BypassAbortSessionApiCall.OPTION_SUCCESS),
+                            ),
                             Config.Entry<Config.Value.BooleanValue>(
                                 key = IdCheckWrapperConfigKey.EnableManualLauncher,
                                 Config.Value.BooleanValue(false),

--- a/test-wrapper/src/test/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/integration/DeveloperSettingsTest.kt
+++ b/test-wrapper/src/test/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/integration/DeveloperSettingsTest.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasScrollToNodeAction
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -11,6 +13,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -133,6 +136,10 @@ class DeveloperSettingsTest {
         composeTestRule
             .onNodeWithText(DEVELOPER_SETTINGS, useUnmergedTree = true)
             .performClick()
+
+        composeTestRule
+            .onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText(NfcConfigKey.NfcAvailability.name))
 
         composeTestRule
             .onNodeWithText(NfcConfigKey.NfcAvailability.name)


### PR DESCRIPTION
## Changes

Add option to configure the abort session API result when bypassing the backend.

## Context

DCMAW-11981

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [x] Check against acceptance criteria
- [x] Add automated tests
- [x] Self-review code
