### PR TITLE
fix: make backend mode dynamic

### DIFF
--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/HandbackNavGraphProvider.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/HandbackNavGraphProvider.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.collections.immutable.toPersistentSet
 import uk.gov.onelogin.criorchestrator.features.handback.internal.modal.AbortModal
@@ -88,6 +89,20 @@ class HandbackNavGraphProvider
                 AbortModal(
                     abortModalViewModel = viewModel(factory = abortModalViewModelFactory),
                     startDestination = AbortDestinations.AbortedReturnToDesktopWeb,
+                    navGraphProviders = abortNavGraphProviders.toPersistentSet(),
+                    onDismissRequest = { navController.popBackStack() },
+                    onFinish = onFinish,
+                )
+            }
+
+            composable<AbortDestinations.AbortedRedirectToMobileWebHolder> { backStackEntry ->
+                val redirectUri =
+                    backStackEntry
+                        .toRoute<AbortDestinations.AbortedRedirectToMobileWebHolder>()
+                        .redirectUri
+                AbortModal(
+                    abortModalViewModel = viewModel(factory = abortModalViewModelFactory),
+                    startDestination = AbortDestinations.AbortedRedirectToMobileWebHolder(redirectUri),
                     navGraphProviders = abortNavGraphProviders.toPersistentSet(),
                     onDismissRequest = { navController.popBackStack() },
                     onFinish = onFinish,

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/activity/IdCheckSdkActivityParameters.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/activity/IdCheckSdkActivityParameters.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.activity
 
-import uk.gov.idcheck.repositories.api.webhandover.backend.BackendMode
 import uk.gov.idcheck.sdk.IdCheckSdkParameters
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.model.LauncherData
 
@@ -10,5 +9,5 @@ internal fun LauncherData.toIdCheckSdkActivityParameters() =
         journey = this.journeyType,
         sessionId = this.sessionId,
         bioToken = this.biometricToken,
-        backendMode = BackendMode.V2,
+        backendMode = this.backendMode,
     )

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/model/LauncherData.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/model/LauncherData.kt
@@ -1,6 +1,7 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.model
 
 import uk.gov.idcheck.repositories.api.vendor.BiometricToken
+import uk.gov.idcheck.repositories.api.webhandover.backend.BackendMode
 import uk.gov.idcheck.repositories.api.webhandover.documenttype.DocumentType
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.JourneyType
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.Session
@@ -11,6 +12,7 @@ data class LauncherData(
     val session: Session,
     val biometricToken: BiometricToken,
     val documentType: DocumentType,
+    val backendMode: BackendMode,
 ) {
     companion object;
 

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenManualLauncherContent.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenManualLauncherContent.kt
@@ -22,6 +22,7 @@ import uk.gov.android.ui.patterns.leftalignedscreen.LeftAlignedScreen
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.android.ui.theme.util.UnstableDesignSystemAPI
 import uk.gov.idcheck.repositories.api.vendor.BiometricToken
+import uk.gov.idcheck.repositories.api.webhandover.backend.BackendMode
 import uk.gov.idcheck.repositories.api.webhandover.documenttype.DocumentType
 import uk.gov.idcheck.repositories.api.webhandover.journeytype.JourneyType
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.model.ExitStateOption
@@ -133,6 +134,7 @@ internal fun PreviewSyncIdCheckManualLauncherContent() {
                             accessToken = "test access token",
                             opaqueId = "test opaque ID",
                         ),
+                    backendMode = BackendMode.V2,
                 ),
             exitStateOptions = ExitStateOption.entries.map { it.displayName }.toPersistentList(),
             selectedExitState = 0,

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/data/LauncherDataReaderTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/data/LauncherDataReaderTest.kt
@@ -10,8 +10,10 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertInstanceOf
 import uk.gov.idcheck.repositories.api.vendor.BiometricToken
+import uk.gov.idcheck.repositories.api.webhandover.backend.BackendMode
 import uk.gov.idcheck.repositories.api.webhandover.documenttype.DocumentType
 import uk.gov.idcheck.repositories.api.webhandover.journeytype.JourneyType
+import uk.gov.onelogin.criorchestrator.features.config.internalapi.FakeConfigStore
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.BiometricTokenResult
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.StubBiometricTokenReader
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.createTestToken
@@ -36,6 +38,7 @@ class LauncherDataReaderTest {
                     session = session,
                     biometricToken = biometricToken,
                     documentType = DocumentType.NFC_PASSPORT,
+                    backendMode = BackendMode.V2,
                 ),
             )
 
@@ -54,6 +57,7 @@ class LauncherDataReaderTest {
                         biometricToken,
                     ),
                 ),
+            configStore = FakeConfigStore(),
         )
 
     @Test

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenAnalyticsTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenAnalyticsTest.kt
@@ -84,6 +84,7 @@ class SyncIdCheckScreenAnalyticsTest {
                                             BiometricToken.createTestToken(),
                                         ),
                                     ),
+                                configStore = FakeConfigStore(),
                             ),
                         logger = SystemLogger(),
                         analytics = analytics,

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenTest.kt
@@ -67,6 +67,7 @@ class SyncIdCheckScreenTest {
                             biometricTokenResult = biometricTokenResult,
                             delay = readerDelay,
                         ),
+                    configStore = FakeConfigStore(),
                 ),
             configStore =
                 FakeConfigStore(

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckViewModelTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckViewModelTest.kt
@@ -73,6 +73,7 @@ class SyncIdCheckViewModelTest {
                                 biometricToken,
                             ),
                         ),
+                    configStore = FakeConfigStore(),
                 ),
             analytics = analytics,
             sessionStore = sessionStore,
@@ -357,6 +358,7 @@ class SyncIdCheckViewModelTest {
                         StubBiometricTokenReader(
                             biometricTokenResult = biometricTokenResult,
                         ),
+                    configStore = FakeConfigStore(),
                 ),
             analytics = analytics,
             configStore =

--- a/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/model/StubLauncherData.kt
+++ b/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/model/StubLauncherData.kt
@@ -1,6 +1,7 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.model
 
 import uk.gov.idcheck.repositories.api.vendor.BiometricToken
+import uk.gov.idcheck.repositories.api.webhandover.backend.BackendMode
 import uk.gov.idcheck.repositories.api.webhandover.documenttype.DocumentType
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.createTestToken
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.Session
@@ -14,4 +15,5 @@ fun LauncherData.Companion.createTestInstance(
     documentType = documentType,
     session = session,
     biometricToken = biometricToken,
+    backendMode = BackendMode.V2,
 )

--- a/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdViewModelExt.kt
+++ b/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdViewModelExt.kt
@@ -33,6 +33,7 @@ fun SyncIdCheckViewModel.Companion.createTestInstance(
                             BiometricToken.createTestToken(),
                         ),
                 ),
+            configStore = configStore,
         ),
     logger: Logger = mock(),
 ) = SyncIdCheckViewModel(


### PR DESCRIPTION
Changes:
- make backend mode in SDK launch parameters dynamic, so that it's `V2` by default but is `Bypass` if bypass ID Check backend is enabled in the dev menu
- add `AbortedRedirectToMobileWebHolder` to handback destinations so it can be navigated from `SyncIdCheckScreen`

## Evidence of the change


## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
