### PR TITLE
feat: add state as query parameter to redirect URI

### DIFF
--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenManualLauncherContent.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenManualLauncherContent.kt
@@ -127,7 +127,6 @@ internal fun PreviewSyncIdCheckManualLauncherContent() {
                     session =
                         Session(
                             sessionId = "test session ID",
-                            state = "test state",
                         ),
                     biometricToken =
                         BiometricToken(

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenTest.kt
@@ -127,7 +127,9 @@ class SyncIdCheckScreenTest {
         composeTestRule.waitForIdle()
 
         verify(navController).navigate(
-            AbortDestinations.AbortedRedirectToMobileWebHolder(redirectUri = "http://mam-redirect-uri"),
+            AbortDestinations.AbortedRedirectToMobileWebHolder(
+                redirectUri = "http://mam-redirect-uri?state=mock-state",
+            ),
         )
     }
 

--- a/features/session/internal-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internalapi/domain/Session.kt
+++ b/features/session/internal-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internalapi/domain/Session.kt
@@ -1,5 +1,11 @@
 package uk.gov.onelogin.criorchestrator.features.session.internalapi.domain
 
+/**
+ * Stores the session information needed for the ID Check journey.
+ * @param sessionId UUID that uniquely identifies the user's session.
+ * @param redirectUri URI that the user is redirected to after the journey, composed of the active session API response
+ * redirect URI and the response state as a query parameter.
+ */
 data class Session(
     val sessionId: String,
     val redirectUri: String? = null,

--- a/features/session/internal-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internalapi/domain/Session.kt
+++ b/features/session/internal-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internalapi/domain/Session.kt
@@ -3,7 +3,6 @@ package uk.gov.onelogin.criorchestrator.features.session.internalapi.domain
 data class Session(
     val sessionId: String,
     val redirectUri: String? = null,
-    val state: String,
 ) {
     companion object;
 }

--- a/features/session/internal-api/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/session/internalapi/domain/StubSession.kt
+++ b/features/session/internal-api/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/session/internalapi/domain/StubSession.kt
@@ -5,12 +5,10 @@ const val REDIRECT_URI = "https://example/redirect"
 fun Session.Companion.createTestInstance(
     sessionId: String = "test-session-id",
     redirectUri: String? = null,
-    state: String = "test-state",
 ): Session =
     Session(
         sessionId = sessionId,
         redirectUri = redirectUri,
-        state = state,
     )
 
 fun Session.Companion.createDesktopAppDesktopInstance(): Session =

--- a/features/session/internal-api/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/session/internalapi/domain/StubSession.kt
+++ b/features/session/internal-api/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/session/internalapi/domain/StubSession.kt
@@ -16,7 +16,9 @@ fun Session.Companion.createDesktopAppDesktopInstance(): Session =
         redirectUri = null,
     )
 
-fun Session.Companion.createMobileAppMobileInstance(redirectUri: String = "http://mam-redirect-uri"): Session =
+fun Session.Companion.createMobileAppMobileInstance(
+    redirectUri: String = "http://mam-redirect-uri?state=mock-state",
+): Session =
     Session.createTestInstance(
         redirectUri = redirectUri,
     )

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReader.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReader.kt
@@ -57,7 +57,7 @@ class RemoteSessionReader
                         if (parsedResponse.redirectUri.isNullOrBlank()) {
                             null
                         } else {
-                            "${parsedResponse.redirectUri}?${parsedResponse.state}"
+                            "${parsedResponse.redirectUri}?state=${parsedResponse.state}"
                         },
                 )
             } catch (e: IllegalArgumentException) {

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReader.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReader.kt
@@ -52,7 +52,13 @@ class RemoteSessionReader
                     json.decodeFromString(response.response.toString())
                 Session(
                     sessionId = parsedResponse.sessionId,
-                    redirectUri = parsedResponse.redirectUri,
+                    // IPV needs the redirect URI to have the state as a query parameter
+                    redirectUri =
+                        if (parsedResponse.redirectUri.isNullOrBlank()) {
+                            null
+                        } else {
+                            "${parsedResponse.redirectUri}?${parsedResponse.state}"
+                        },
                     state = parsedResponse.state,
                 )
             } catch (e: IllegalArgumentException) {

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReader.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReader.kt
@@ -59,7 +59,6 @@ class RemoteSessionReader
                         } else {
                             "${parsedResponse.redirectUri}?${parsedResponse.state}"
                         },
-                    state = parsedResponse.state,
                 )
             } catch (e: IllegalArgumentException) {
                 logger.error(tag, "Failed to parse active session response", e)

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
@@ -75,7 +75,7 @@ class IntegrationTest {
             val expectedSession =
                 Session(
                     sessionId = "37aae92b-a51e-4f68-b571-8e455fb0ec34",
-                    redirectUri = "https://example/redirect?11112222333344445555666677778888",
+                    redirectUri = "https://example/redirect?state=11112222333344445555666677778888",
                 )
             sessionStore.read().test {
                 assertEquals(

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
@@ -76,7 +76,6 @@ class IntegrationTest {
                 Session(
                     sessionId = "37aae92b-a51e-4f68-b571-8e455fb0ec34",
                     redirectUri = "https://example/redirect?11112222333344445555666677778888",
-                    state = "11112222333344445555666677778888",
                 )
             sessionStore.read().test {
                 assertEquals(

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
@@ -75,7 +75,7 @@ class IntegrationTest {
             val expectedSession =
                 Session(
                     sessionId = "37aae92b-a51e-4f68-b571-8e455fb0ec34",
-                    redirectUri = "https://example/redirect",
+                    redirectUri = "https://example/redirect?11112222333344445555666677778888",
                     state = "11112222333344445555666677778888",
                 )
             sessionStore.read().test {

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
@@ -123,7 +123,6 @@ class RemoteSessionReaderTest {
                     Session(
                         sessionId = "test session ID",
                         redirectUri = "https://example/redirect?11112222333344445555666677778888",
-                        state = "11112222333344445555666677778888",
                     ),
                 ),
                 arguments(
@@ -146,7 +145,6 @@ class RemoteSessionReaderTest {
                     Session(
                         sessionId = "test session ID",
                         redirectUri = "https://example/redirect?11112222333344445555666677778888",
-                        state = "11112222333344445555666677778888",
                     ),
                 ),
                 arguments(
@@ -167,7 +165,6 @@ class RemoteSessionReaderTest {
                     Session(
                         sessionId = "test session ID",
                         redirectUri = null,
-                        state = "11112222333344445555666677778888",
                     ),
                 ),
                 arguments(

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
@@ -106,7 +106,7 @@ class RemoteSessionReaderTest {
                 // This test will also fail if the serialization plugin isn't applied
                 arguments(
                     named(
-                        "true with expected log entry when API response is Success with correct" +
+                        "true with expected log entry when API response is Success with correct " +
                             "response format - with redirectUri (mobile journey)",
                         ApiResponse.Success<String>(
                             """
@@ -127,7 +127,7 @@ class RemoteSessionReaderTest {
                 ),
                 arguments(
                     named(
-                        "true with expected log entry when API response is Success with correct" +
+                        "true with expected log entry when API response is Success with correct " +
                             "response format - with new parameters",
                         ApiResponse.Success<String>(
                             """
@@ -149,7 +149,7 @@ class RemoteSessionReaderTest {
                 ),
                 arguments(
                     named(
-                        "true with expected log entry when API response is Success with correct" +
+                        "true with expected log entry when API response is Success with correct " +
                             "response format - with existing query parameters on the redirect URI",
                         ApiResponse.Success<String>(
                             """
@@ -170,7 +170,7 @@ class RemoteSessionReaderTest {
                 ),
                 arguments(
                     named(
-                        "true with expected log entry when API response is Success with correct" +
+                        "true with expected log entry when API response is Success with correct " +
                             "response format - with state that requires URI encoding",
                         ApiResponse.Success<String>(
                             """
@@ -191,7 +191,7 @@ class RemoteSessionReaderTest {
                 ),
                 arguments(
                     named(
-                        "true with expected log entry when API response is Success with correct" +
+                        "true with expected log entry when API response is Success with correct " +
                             "response format - no redirectUri (desktop journey)",
                         ApiResponse.Success<String>(
                             """

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
@@ -150,6 +150,48 @@ class RemoteSessionReaderTest {
                 arguments(
                     named(
                         "true with expected log entry when API response is Success with correct" +
+                            "response format - with existing query parameters on the redirect URI",
+                        ApiResponse.Success<String>(
+                            """
+                            {
+                                "sessionId": "test session ID",
+                                "redirectUri": "https://example/redirect?test=test",
+                                "state": "11112222333344445555666677778888"
+                            }
+                            """.trimIndent(),
+                        ),
+                    ),
+                    "Got active session",
+                    true,
+                    Session(
+                        sessionId = "test session ID",
+                        redirectUri = "https://example/redirect?test=test&state=11112222333344445555666677778888",
+                    ),
+                ),
+                arguments(
+                    named(
+                        "true with expected log entry when API response is Success with correct" +
+                            "response format - with state that requires URI encoding",
+                        ApiResponse.Success<String>(
+                            """
+                            {
+                                "sessionId": "test session ID",
+                                "redirectUri": "https://example/redirect",
+                                "state": "&?%:/"
+                            }
+                            """.trimIndent(),
+                        ),
+                    ),
+                    "Got active session",
+                    true,
+                    Session(
+                        sessionId = "test session ID",
+                        redirectUri = "https://example/redirect?state=%26%3F%25%3A%2F",
+                    ),
+                ),
+                arguments(
+                    named(
+                        "true with expected log entry when API response is Success with correct" +
                             "response format - no redirectUri (desktop journey)",
                         ApiResponse.Success<String>(
                             """

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
@@ -122,7 +122,7 @@ class RemoteSessionReaderTest {
                     true,
                     Session(
                         sessionId = "test session ID",
-                        redirectUri = "https://example/redirect?11112222333344445555666677778888",
+                        redirectUri = "https://example/redirect?state=11112222333344445555666677778888",
                     ),
                 ),
                 arguments(
@@ -144,7 +144,7 @@ class RemoteSessionReaderTest {
                     true,
                     Session(
                         sessionId = "test session ID",
-                        redirectUri = "https://example/redirect?11112222333344445555666677778888",
+                        redirectUri = "https://example/redirect?state=11112222333344445555666677778888",
                     ),
                 ),
                 arguments(

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/data/InMemorySessionStoreTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/data/InMemorySessionStoreTest.kt
@@ -21,7 +21,6 @@ class InMemorySessionStoreTest {
             Session(
                 sessionId = "test session ID",
                 redirectUri = "test redirect URI",
-                state = "test state",
             )
 
         sessionStore.write(newSession)


### PR DESCRIPTION
Changes:
- add state as query parameter to redirect URI
- removed state from repository as unused in code (aside from as query parameter above) - happy to discuss whether this is needed, can revert the commit

## Evidence
| Happy Path | Abort Path |
| - | - |
| <video src="https://github.com/user-attachments/assets/4ef85614-b032-43c2-9408-14bce4418f37"> | <video src="https://github.com/user-attachments/assets/12f69bbb-4cfd-4670-8f4b-ac84a9ea6f7f"> |

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
