### PR TITLE
build: bump SDK version to 0.13.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ turbine = "1.2.0"
 uk-gov-logging = "0.24.3" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.7.2"
 uk-gov-ui = "7.27.1"
-gov-uk-idcheck = "0.13.0"
+gov-uk-idcheck = "0.13.1"
 
 [libraries]
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }

--- a/gradle/testwrapperlibs.versions.toml
+++ b/gradle/testwrapperlibs.versions.toml
@@ -6,7 +6,7 @@ dagger = "2.56.1"
 firebase-bom = "33.12.0" # https://firebase.google.com/support/release-notes/android
 firebase-crashlytics-gradle = "3.0.3" # https://firebase.google.com/support/release-notes/android
 google-services = "4.4.2" # https://developers.google.com/android/guides/releases
-gov-uk-idcheck = "0.13.0"
+gov-uk-idcheck = "0.13.1"
 
 [libraries]
 firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }


### PR DESCRIPTION
# DCMAW-13562: Fix FaceScanLimitReached Exit State Defect
- Fix made in SDK - bumping version to propagate changes.
- Cannot test at this stage, only in One Login via E2E tests

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
