### PR TITLE
fix: Focus stuck issue

### DIFF
--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/select/SelectPassportScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/select/SelectPassportScreen.kt
@@ -155,7 +155,7 @@ internal fun SelectPassportScreenContent(
                     modifier = Modifier.fillMaxWidth(),
                 )
             },
-            forceScroll = true
+            forceScroll = true,
         )
     }
 }

--- a/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/select/SelectPassportScreen.kt
+++ b/features/select-doc/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/selectdoc/internal/passport/select/SelectPassportScreen.kt
@@ -155,6 +155,7 @@ internal fun SelectPassportScreenContent(
                     modifier = Modifier.fillMaxWidth(),
                 )
             },
+            forceScroll = true
         )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ testparameterinjector = "1.18"
 turbine = "1.2.0"
 uk-gov-logging = "0.25.2" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.7.2"
-uk-gov-ui = "7.31.1"
+uk-gov-ui = "7.31.2"
 gov-uk-idcheck = "0.13.1"
 
 [libraries]


### PR DESCRIPTION
# DCMAW-13487: Focus stuck on the close button

- set forceScroll parameter in LeftAlignedScreen to true

This is a partial fix. The reported defect occurs when the display text and display images are set to the maximum size. The correct behaviour is to scroll to the next focusable element when the user taps the down arrow button on their keyboard. With this fix, a second down arrow tap is required and this also occurs when the display text and images are at smaller / normal sizes.

## Evidence of the change


https://github.com/user-attachments/assets/e87fd14b-cb7e-4abf-99e2-79cbcb6f12e4


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [x] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
