### PR TITLE
build: Update test wrapper to target Android 15 (API 35)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ val apkConfig by rootProject.extra(
         override val debugVersion: String = "DEBUG_VERSION"
         override val sdkVersions = object : ApkConfig.SdkVersions {
             override val minimum = 29
-            override val target = 34
+            override val target = 35
             override val compile = 35
         }
     }


### PR DESCRIPTION
## Changes

Update the test wrapper app to target Android 15.

## Context

This aligns the target SDK version with the GOV.UK One Login app and surfaces an issue in ID Check SDK: DCMAW-13740

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
