### PR TITLE
build: Enable Gradle build optimisations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,19 +4,19 @@
 # any settings specified in this file.
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
+
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. For more details, visit
-# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
+
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
+
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
 # Enables namespacing of each library's R class so that its R class includes only the
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
@@ -24,3 +24,7 @@ android.nonTransitiveRClass=true
 
 android.experimental.enableTestFixtures=true
 android.experimental.enableTestFixturesKotlinSupport=true
+
+org.gradle.caching=true
+org.gradle.configureondemand=true
+org.gradle.parallel=true


### PR DESCRIPTION
## Changes

- Enable Gradle parallel builds
- Enable the Gradle build cache
- Enable Gradle configuration on demand

## Context

Improves the build performance:

- Parallel builds allows different modules to build and test in parallel
- The build cache allows builds to save time by reusing the other builds' outputs
- Configuration-on-demand allows a build to skip configuration for modules that aren't needed (for example when running tests for a single module)

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
