### PR TITLE
ci: Prevent race condition when bumping version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -10,6 +10,10 @@ on:
 env:
   WORKFLOW_OUT_DIR: ./workflow-outputs
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   bump-version:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
## Changes

Ensure the `bump_version` workflow can't run in parallel to avoid race conditions between releases.

## Context

![image](https://github.com/user-attachments/assets/720d4995-8526-43e4-9c86-bcf421b8ec6b)

```
Run git push --follow-tags && git push --tags
To https://github.com/govuk-one-login/mobile-android-cri-orchestrator
 ! [rejected]          main -> main (fetch first)
error: failed to push some refs to 'https://github.com/govuk-one-login/mobile-android-cri-orchestrator'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally. This is usually caused by another repository pushing to
hint: the same ref. If you want to integrate the remote changes, use
hint: 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.
```

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
