### PR TITLE
chore: add sdk app name string

### DIFF
--- a/test-wrapper/src/main/res/values/strings.xml
+++ b/test-wrapper/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name" translatable="false">CRI Orchestrator</string>
-    <string name="appName" translatable="false">@string/app_name</string>
+
+    <!-- Required in the ID Check SDK -->
+    <string name="appName" translatable="false" tools:ignore="UnusedResources">@string/app_name</string>
 </resources>


### PR DESCRIPTION
# DCMAW-12794 - app name variable

- Add the `appName` required in ID Check SDK

https://github.com/govuk-one-login/mobile-id-check-android-sdk/blob/66304bec3709662400251e684b1f008626ebbd15/modules/idcheck/network-api/src/main/res/values/strings.xml

The plan is to name space the id check sdk strings so this will change to `idsdk_app_name` in the future

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
