### PR TITLE
chore: add one login app name

### DIFF
--- a/sdk/internal/src/main/res/values/strings.xml
+++ b/sdk/internal/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <!-- Required in the ID Check SDK -->
+    <string name="appName" translatable="false" tools:ignore="UnusedResources">One Login</string>
+</resources>


### PR DESCRIPTION
# DCMAW-12794

- Add the appName required in ID Check SDK

https://github.com/govuk-one-login/mobile-id-check-android-sdk/blob/66304bec3709662400251e684b1f008626ebbd15/modules/idcheck/network-api/src/main/res/values/strings.xml

Currently (and for the foreseeable future) only One Login uses CRI Orchestrator so it's safe to have this hardcoded.
If this changes, then the consumer app name needs to passed in as well.


## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
