### PR TITLE
fix: add content descriptions to external buttons

### DIFF
--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/abort/confirm/mobile/ConfirmAbortMobileScreen.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/abort/confirm/mobile/ConfirmAbortMobileScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.contentDescription
@@ -21,6 +22,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import uk.gov.android.ui.componentsv2.R.drawable.ic_external_site
+import uk.gov.android.ui.componentsv2.R.string.opens_in_external_browser
 import uk.gov.android.ui.componentsv2.button.ButtonType
 import uk.gov.android.ui.componentsv2.button.GdsButton
 import uk.gov.android.ui.componentsv2.heading.GdsHeading
@@ -134,6 +136,7 @@ internal fun ConfirmAbortMobileWebContent(
                 }
             },
             primaryButton = {
+                val contentDescription = ". ${stringResource(opens_in_external_browser)}"
                 GdsButton(
                     text = stringResource(ConfirmAbortMobileConstants.buttonId),
                     onClick = dropUnlessResumed { onButtonClick() },
@@ -148,7 +151,7 @@ internal fun ConfirmAbortMobileWebContent(
                                 ),
                             fontWeight = FontWeight.Bold,
                             iconImage = ImageVector.vectorResource(ic_external_site),
-                            contentDescription = "Opens in external browser",
+                            contentDescription = contentDescription,
                         ),
                     modifier = Modifier.fillMaxWidth(),
                 )

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/abort/confirm/mobile/ConfirmAbortMobileScreen.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/abort/confirm/mobile/ConfirmAbortMobileScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.contentDescription

--- a/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreen.kt
+++ b/features/handback/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreen.kt
@@ -113,6 +113,7 @@ private fun ReturnToMobileWebScreenContent(
                 }
             },
             primaryButton = {
+                val contentDescription = ". ${stringResource(opens_in_external_browser)}"
                 GdsButton(
                     text = stringResource(ReturnToMobileWebConstants.buttonId),
                     buttonType =
@@ -126,7 +127,7 @@ private fun ReturnToMobileWebScreenContent(
                                 ),
                             fontWeight = FontWeight.Bold,
                             iconImage = ImageVector.vectorResource(ic_external_site),
-                            contentDescription = stringResource(opens_in_external_browser),
+                            contentDescription = contentDescription,
                         ),
                     onClick = dropUnlessResumed { onButtonClick() },
                     modifier = Modifier.fillMaxWidth(),

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/abort/confirm/mobile/ConfirmAbortMobileScreenTest.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/abort/confirm/mobile/ConfirmAbortMobileScreenTest.kt
@@ -66,7 +66,6 @@ class ConfirmAbortMobileScreenTest {
 
     @Test
     fun `when talkback is enabled, it reads out Gov dot UK correctly`() {
-
         val body =
             composeTestRule
                 .onNode(hasText(context.getString(R.string.handback_confirmabort_body1)))
@@ -75,12 +74,13 @@ class ConfirmAbortMobileScreenTest {
 
     @Test
     fun `when talkback is enabled, it reads out external site button correctly`() {
-        composeTestRule.onNode(
-            hasText(
-                context.getString(R.string.handback_confirmabortmobileweb_button),
-                true,
-            ),
-        ).assertContentDescriptionContains(". opens in web browser")
+        composeTestRule
+            .onNode(
+                hasText(
+                    context.getString(R.string.handback_confirmabortmobileweb_button),
+                    true,
+                ),
+            ).assertContentDescriptionContains(". opens in web browser")
     }
 
     @Test

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/abort/confirm/mobile/ConfirmAbortMobileScreenTest.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/abort/confirm/mobile/ConfirmAbortMobileScreenTest.kt
@@ -66,12 +66,21 @@ class ConfirmAbortMobileScreenTest {
 
     @Test
     fun `when talkback is enabled, it reads out Gov dot UK correctly`() {
-        val context: Context = ApplicationProvider.getApplicationContext()
 
         val body =
             composeTestRule
                 .onNode(hasText(context.getString(R.string.handback_confirmabort_body1)))
         body.assertContentDescriptionContains("Gov dot UK", true)
+    }
+
+    @Test
+    fun `when talkback is enabled, it reads out external site button correctly`() {
+        composeTestRule.onNode(
+            hasText(
+                context.getString(R.string.handback_confirmabortmobileweb_button),
+                true,
+            ),
+        ).assertContentDescriptionContains(". opens in web browser")
     }
 
     @Test

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreenTest.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreenTest.kt
@@ -78,11 +78,12 @@ class ReturnToMobileWebScreenTest {
 
     @Test
     fun `when talkback is enabled, it reads out external site button correctly`() {
-        composeTestRule.onNode(
-            hasText(
-                context.getString(R.string.handback_returntomobileweb_button),
-                true,
-            ),
-        ).assertContentDescriptionContains(". opens in web browser")
+        composeTestRule
+            .onNode(
+                hasText(
+                    context.getString(R.string.handback_returntomobileweb_button),
+                    true,
+                ),
+            ).assertContentDescriptionContains(". opens in web browser")
     }
 }

--- a/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreenTest.kt
+++ b/features/handback/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/handback/internal/returntomobileweb/ReturnToMobileWebScreenTest.kt
@@ -26,6 +26,8 @@ class ReturnToMobileWebScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
+    val context: Context = ApplicationProvider.getApplicationContext()
+
     private val session =
         Session.createTestInstance(
             redirectUri = REDIRECT_URI,
@@ -53,7 +55,6 @@ class ReturnToMobileWebScreenTest {
 
     @Test
     fun `when continue to gov uk website button is clicked, it opens the session redirect uri`() {
-        val context: Context = ApplicationProvider.getApplicationContext()
         composeTestRule
             .onNode(
                 hasTextStartingWith(context.getString(ReturnToMobileWebConstants.buttonId)),
@@ -64,7 +65,6 @@ class ReturnToMobileWebScreenTest {
 
     @Test
     fun `when talkback is enabled, it reads out Gov dot UK correctly`() {
-        val context: Context = ApplicationProvider.getApplicationContext()
         val title =
             composeTestRule
                 .onNode(hasText(context.getString(ReturnToMobileWebConstants.titleId)))
@@ -74,5 +74,15 @@ class ReturnToMobileWebScreenTest {
             composeTestRule
                 .onNode(hasText(context.getString(R.string.handback_returntomobileweb_body2)))
         body.assertContentDescriptionContains("Gov dot UK", true)
+    }
+
+    @Test
+    fun `when talkback is enabled, it reads out external site button correctly`() {
+        composeTestRule.onNode(
+            hasText(
+                context.getString(R.string.handback_returntomobileweb_button),
+                true,
+            ),
+        ).assertContentDescriptionContains(". opens in web browser")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ turbine = "1.2.1"
 uk-gov-logging = "0.26.0" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.7.2"
 uk-gov-ui = "7.33.1"
-gov-uk-idcheck = "0.19.0"
+gov-uk-idcheck = "0.19.1"
 
 [libraries]
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }


### PR DESCRIPTION
# DCMAW-13494: Add content descriptions to external buttons

- add content descriptions to `ConfirmMobileAbort` and `ReturnToMobileWeb` screens
- add tests

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [x] Add automated tests
- [x] Self-review code
