### PR TITLE
build: DCMAW-14174 Bump ID Check SDK version to 0.19.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ turbine = "1.2.1"
 uk-gov-logging = "0.26.0" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.7.2"
 uk-gov-ui = "7.33.1"
-gov-uk-idcheck = "0.19.2"
+gov-uk-idcheck = "0.19.4"
 
 [libraries]
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }


### PR DESCRIPTION
Resolves: DCMAW-14174

[Tutorial for writing good descriptions]: https://cbea.ms/git-commit/

[//]: # (Be mindful that the PR title also needs to follow conventional commit standards)

# DCMAW-14174: Bump ID Check SDK version to 0.19.4

- Contains fixes to the BRP `Screen_ID` analytics bug - which caused the same `Screen_ID` to appear for multiple screens

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
