### PR TITLE
build: DCMAW-13452 Bump ID Check SDK version to 0.22.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ turbine = "1.2.1"
 uk-gov-logging = "0.26.0" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.7.2"
 uk-gov-ui = "7.33.1"
-gov-uk-idcheck = "0.20.1"
+gov-uk-idcheck = "0.22.0"
 
 [libraries]
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }


### PR DESCRIPTION
[Tutorial for writing good descriptions]: https://cbea.ms/git-commit/

# DCMAW-13452 Bump ID Check SDK version to 0.22.0

- Contains updated v3.1 analytics schema for the `TooManyRequestsError` screen

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
