### PR TITLE
fix: DCMAW-14463 SyncIdCheck loading state prod crash

### DIFF
--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/activity/UnavailableIdCheckSdkActivityResultContract.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/activity/UnavailableIdCheckSdkActivityResultContract.kt
@@ -3,9 +3,16 @@ package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.activit
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
+import uk.gov.idcheck.sdk.IdCheckSdkActivityResultContract
 import uk.gov.idcheck.sdk.IdCheckSdkExitState
 import uk.gov.idcheck.sdk.IdCheckSdkParameters
 
+/**
+ * This contract is unable to launch intents, but is able to parse intents and transform them into exit states.
+ * This is because if the app activity that launches the ID Check SDK dies during the ID Check SDK journey, when
+ * the ID Check SDK hands back to the CRI Orchestrator screen, the activity is recreated and thos contract is used
+ * by default and so must be able to parse the intent correctly.
+ */
 internal class UnavailableIdCheckSdkActivityResultContract :
     ActivityResultContract<
         IdCheckSdkParameters,
@@ -19,7 +26,7 @@ internal class UnavailableIdCheckSdkActivityResultContract :
     override fun parseResult(
         resultCode: Int,
         intent: Intent?,
-    ): IdCheckSdkExitState = fail()
+    ): IdCheckSdkExitState = IdCheckSdkActivityResultContract.defaultParseResultBehaviour().transform(intent)
 
     private fun fail(): Nothing = error("Can't launch ID Check SDK while loading")
 }

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/activity/UnavailableIdCheckSdkActivityResultContract.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/activity/UnavailableIdCheckSdkActivityResultContract.kt
@@ -10,7 +10,7 @@ import uk.gov.idcheck.sdk.IdCheckSdkParameters
 /**
  * This contract is unable to launch intents, but is able to parse intents and transform them into exit states.
  * This is because if the app activity that launches the ID Check SDK dies during the ID Check SDK journey, when
- * the ID Check SDK hands back to the CRI Orchestrator screen, the activity is recreated and thos contract is used
+ * the ID Check SDK hands back to the CRI Orchestrator screen, the activity is recreated and this contract is used
  * by default and so must be able to parse the intent correctly.
  */
 internal class UnavailableIdCheckSdkActivityResultContract :

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckViewModel.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckViewModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.screen
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.delay
@@ -26,10 +27,13 @@ import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.Docum
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.idchecksdkactivestate.IdCheckSdkActiveStateStore
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.JourneyType
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionStore
+import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.journeyType
 
 private const val STUB_BIOMETRIC_TOKEN_DELAY_MS = 2000L
 
+@Suppress("LongParameterList")
 class SyncIdCheckViewModel(
+    private val savedStateHandle: SavedStateHandle,
     private val configStore: ConfigStore,
     private val sessionStore: SessionStore,
     private val idCheckSdkActiveStateStore: IdCheckSdkActiveStateStore,
@@ -42,9 +46,14 @@ class SyncIdCheckViewModel(
 
     private val _actions = MutableSharedFlow<SyncIdCheckAction>(replay = 1)
     val actions = _actions.asSharedFlow()
-    var sdkHasDisplayed = false
+    var sdkHasDisplayed: Boolean =
+        savedStateHandle.get(
+            key = SDK_HAS_DISPLAYED,
+        ) ?: initiallyReturnFalse()
 
-    companion object;
+    companion object {
+        const val SDK_HAS_DISPLAYED = "uk.gov.onelogin.criorchestrator.sdkHasDisplayed"
+    }
 
     fun onScreenStart(documentVariety: DocumentVariety) {
         analytics.trackScreen(
@@ -113,7 +122,7 @@ class SyncIdCheckViewModel(
 
     fun onIdCheckSdkLaunchRequest(launcherData: LauncherData) {
         if (!sdkHasDisplayed) {
-            sdkHasDisplayed = true
+            updateSdkHasDisplayed(true)
             idCheckSdkActiveStateStore.setActive()
             viewModelScope.launch {
                 _actions.emit(
@@ -131,8 +140,7 @@ class SyncIdCheckViewModel(
         if (exitState.hasAbortedSession()) {
             sessionStore.updateToAborted()
         }
-
-        val journeyType = requireDisplayState().launcherData.sessionJourneyType
+        val journeyType = sessionStore.read().value!!.journeyType
         val action =
             when (exitState.isSuccess()) {
                 true ->
@@ -198,4 +206,14 @@ class SyncIdCheckViewModel(
     }
 
     private fun requireDisplayState() = _state.value as? SyncIdCheckState.Display ?: error("Expected display state")
+
+    private fun updateSdkHasDisplayed(state: Boolean) {
+        sdkHasDisplayed = state
+        savedStateHandle[SDK_HAS_DISPLAYED] = state
+    }
+
+    private fun initiallyReturnFalse(): Boolean {
+        savedStateHandle[SDK_HAS_DISPLAYED] = false
+        return false
+    }
 }

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckViewModel.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckViewModel.kt
@@ -47,9 +47,7 @@ class SyncIdCheckViewModel(
     private val _actions = MutableSharedFlow<SyncIdCheckAction>(replay = 1)
     val actions = _actions.asSharedFlow()
     var sdkHasDisplayed: Boolean =
-        savedStateHandle.get(
-            key = SDK_HAS_DISPLAYED,
-        ) ?: initiallyReturnFalse()
+        savedStateHandle[SDK_HAS_DISPLAYED] ?: initiallyReturnFalse()
 
     companion object {
         const val SDK_HAS_DISPLAYED = "uk.gov.onelogin.criorchestrator.sdkHasDisplayed"

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckViewModelModule.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckViewModelModule.kt
@@ -1,6 +1,7 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.screen
 
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.squareup.anvil.annotations.ContributesTo
@@ -40,6 +41,7 @@ object SyncIdCheckViewModelModule {
                     launcherDataReader = launcherDataReader,
                     logger = logger,
                     analytics = analytics,
+                    savedStateHandle = createSavedStateHandle(),
                 )
             }
         }

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenAnalyticsTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenAnalyticsTest.kt
@@ -3,6 +3,7 @@ package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.screen
 import android.content.Context
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.compose.rememberNavController
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -98,6 +99,10 @@ class SyncIdCheckScreenAnalyticsTest {
                                     ),
                             ),
                         idCheckSdkActiveStateStore = InMemoryIdCheckSdkActiveStateStore(logger),
+                        savedStateHandle =
+                            SavedStateHandle(
+                                mapOf(SyncIdCheckViewModel.SDK_HAS_DISPLAYED to false),
+                            ),
                     ),
             )
         }

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckViewModelTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckViewModelTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.screen
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
@@ -53,7 +54,9 @@ class SyncIdCheckViewModelTest {
     private var session = Session.createTestInstance()
     private val biometricToken = BiometricToken.createTestToken()
     private val analytics = mock<IdCheckWrapperAnalytics>()
-    private val sessionStore = FakeSessionStore(session)
+    private val sessionStore by lazy {
+        FakeSessionStore(session)
+    }
     private val configStore: ConfigStore = FakeConfigStore()
     private val idCheckSdkActiveStateStore = InMemoryIdCheckSdkActiveStateStore(logger)
     private val launcherData by lazy {
@@ -89,6 +92,10 @@ class SyncIdCheckViewModelTest {
             analytics = analytics,
             sessionStore = sessionStore,
             idCheckSdkActiveStateStore = idCheckSdkActiveStateStore,
+            savedStateHandle =
+                SavedStateHandle(
+                    mapOf(SyncIdCheckViewModel.SDK_HAS_DISPLAYED to false),
+                ),
         )
     }
 
@@ -385,6 +392,10 @@ class SyncIdCheckViewModelTest {
             ),
         sessionStore = sessionStore,
         idCheckSdkActiveStateStore = InMemoryIdCheckSdkActiveStateStore(logger),
+        savedStateHandle =
+            SavedStateHandle(
+                mapOf(SyncIdCheckViewModel.SDK_HAS_DISPLAYED to false),
+            ),
     )
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdViewModelExt.kt
+++ b/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdViewModelExt.kt
@@ -1,5 +1,6 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.screen
 
+import androidx.lifecycle.SavedStateHandle
 import org.mockito.Mockito.mock
 import uk.gov.idcheck.repositories.api.vendor.BiometricToken
 import uk.gov.logging.api.Logger
@@ -46,4 +47,8 @@ fun SyncIdCheckViewModel.Companion.createTestInstance(
     analytics = mock(),
     idCheckSdkActiveStateStore = idCheckSdkActiveStateStore,
     sessionStore = sessionStore,
+    savedStateHandle =
+        SavedStateHandle(
+            mapOf(SyncIdCheckViewModel.SDK_HAS_DISPLAYED to false),
+        ),
 )


### PR DESCRIPTION
# DCMAW-14463: Fix SyncIdCheck crash when activity killed in background

- When the user is
1.  partway through the ID Check SDK journey
2. and the activity containing the CRI Orchestrator screens (i.e. One Login activity) is killed in the background (maybe due to resource constraints or the user has been on the ID Check SDK journey for a long time)
3. then when the ID Check SDK is exited with an Exit State and handed back to the CRI Orchestrator
4. the app crashes as the CRI Orchestrator's `SyncIdCheckScreen` is in a `loading` state, which is unable to parse results of the `activityResultContract` that was used to launch the ID Check SDK

These changes:
- enable the `loading` state to parse the results of the `activityResultContract`
- enable the `SyncIdCheckScreen` `hasSdkDisplayed` state to persist through activity death (via `savedStateHandle`) so it doesn't try to launch the SDK again (and in doing so show an error)

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change
Happy path
| Before Changes | After Changes |
| - | - |
| Crashes <video src="https://github.com/user-attachments/assets/0c5a68c9-93b1-4cd8-97fa-4038806a4127"> | No crash <video src="https://github.com/user-attachments/assets/b85a676c-a7c9-4830-8608-8cabea7488eb"> |


Abort
| Before Changes | Without `SavedStateHandle` | After Changes |
| - | - | - |
| Crashes <video src="https://github.com/user-attachments/assets/55794420-38c6-4df1-984f-a5b67deb1543"> | No crash but errors <video src="https://github.com/user-attachments/assets/ca3512b6-33b5-4317-b7df-6e5ac823d346"> | No crash, no error <video src="https://github.com/user-attachments/assets/c8a122c1-9933-485e-bd98-427997121084"> |



[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [x] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
