### PR TITLE
build: DCMAW-14867 bump ID Check SDK version to 0.25.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ turbine = "1.2.1"
 uk-gov-logging = "0.31.0" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.7.2"
 uk-gov-ui = "7.41.2"
-gov-uk-idcheck = "0.25.1"
+gov-uk-idcheck = "0.25.4"
 
 [libraries]
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }


### PR DESCRIPTION
# DCMAW-14867: Bump ID Check SDK version to 0.25.4

- Fix `Go back and Try again` button recovery action bug on the `Your information couldn’t be submitted` screen

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
