### PR TITLE
build: Update Firebase BOM to 34.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ turbine = "1.2.1"
 uk-gov-logging = "0.31.0" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.7.2"
 uk-gov-ui = "7.41.3"
-gov-uk-idcheck = "0.25.7"
+gov-uk-idcheck = "0.25.8"
 
 [libraries]
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }

--- a/gradle/testwrapperlibs.versions.toml
+++ b/gradle/testwrapperlibs.versions.toml
@@ -3,14 +3,14 @@
 
 [versions]
 dagger = "2.57"
-firebase-bom = "33.12.0" # https://firebase.google.com/support/release-notes/android
-firebase-crashlytics-gradle = "3.0.3" # https://firebase.google.com/support/release-notes/android
+firebase-bom = "34.1.0" # https://firebase.google.com/support/release-notes/android
+firebase-crashlytics-gradle = "3.0.6" # https://firebase.google.com/support/release-notes/android
 google-services = "4.4.2" # https://developers.google.com/android/guides/releases
 
 [libraries]
-firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
-firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "dagger" }
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "dagger" }
 uk-gov-idcheck-hilt-config = { module = "uk.gov.onelogin.idcheck:hilt-config" }

--- a/test-wrapper/src/staging/kotlin/uk/gov/documentchecking/analytics/AnalyticsSingletonModule.kt
+++ b/test-wrapper/src/staging/kotlin/uk/gov/documentchecking/analytics/AnalyticsSingletonModule.kt
@@ -1,8 +1,8 @@
 package uk.gov.documentchecking.analytics
 
+import com.google.firebase.Firebase
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.analytics
-import com.google.firebase.Firebase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/test-wrapper/src/staging/kotlin/uk/gov/documentchecking/analytics/AnalyticsSingletonModule.kt
+++ b/test-wrapper/src/staging/kotlin/uk/gov/documentchecking/analytics/AnalyticsSingletonModule.kt
@@ -1,8 +1,8 @@
 package uk.gov.documentchecking.analytics
 
 import com.google.firebase.analytics.FirebaseAnalytics
-import com.google.firebase.analytics.ktx.analytics
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.analytics.analytics
+import com.google.firebase.Firebase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn


### PR DESCRIPTION
# Update Firebase BOM to 34.1.0

- Update Firebase BOM to 34.1.0
- Migrate from `-ktx` to core dependencies
- Also update Firebase Crashlytics Gradle Plugin to 3.0.6

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
