### PR TITLE
fix!: Fix package for `IdCheckWrapperConfigKey`

### DIFF
--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckViewModel.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckViewModel.kt
@@ -25,6 +25,7 @@ import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.model.Ex
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.model.LauncherData
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.idchecksdkactivestate.IdCheckSdkActiveStateStore
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.publicapi.IdCheckWrapperConfigKey
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.JourneyType
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.SessionStore
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.journeyType

--- a/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/config/StubIdCheckWrapperConfig.kt
+++ b/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/config/StubIdCheckWrapperConfig.kt
@@ -1,9 +1,9 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.config
 
-import IdCheckWrapperConfigKey
 import kotlinx.collections.immutable.persistentListOf
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.publicapi.IdCheckWrapperConfigKey
 
 fun Config.Companion.createTestInstance(
     enableManualLauncher: Boolean = false,

--- a/features/id-check-wrapper/public-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/publicapi/IdCheckWrapperConfigKey.kt
+++ b/features/id-check-wrapper/public-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/publicapi/IdCheckWrapperConfigKey.kt
@@ -1,3 +1,5 @@
+package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.publicapi
+
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.BooleanConfigKey
 
 /**

--- a/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/config/DefaultConfig.kt
+++ b/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/config/DefaultConfig.kt
@@ -3,6 +3,7 @@ package uk.gov.onelogin.criorchestrator.sdk.internal.config
 import kotlinx.collections.immutable.persistentListOf
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.publicapi.IdCheckWrapperConfigKey
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.publicapi.nfc.NfcConfigKey
 
 private val defaultConfig =

--- a/sdk/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/CriOrchestratorSingletonImplTest.kt
+++ b/sdk/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/CriOrchestratorSingletonImplTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mockito.mock
 import uk.gov.onelogin.criorchestrator.features.config.internal.ConfigComponent
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.publicapi.IdCheckWrapperConfigKey
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.publicapi.nfc.NfcConfigKey
 
 class CriOrchestratorSingletonImplTest {

--- a/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/TestWrapperConfig.kt
+++ b/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/TestWrapperConfig.kt
@@ -4,6 +4,7 @@ import android.content.res.Resources
 import kotlinx.collections.immutable.persistentListOf
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
+import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.publicapi.IdCheckWrapperConfigKey
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.publicapi.nfc.NfcConfigKey
 
 object TestWrapperConfig {


### PR DESCRIPTION
## Changes

- BREAKING CHANGE: Fix missing package for `IdCheckWrapperConfigKey`.

## Context

This missing package is unlikely to be a major problem for consumers however it is automatically fixed when using 'Optimise Imports' in Android Studio, causing unwanted changes. Fixing this package separately avoids polluting other PRs.

## Release notes

If you use `IdCheckWrapperConfigKey` in your project, you should add a fully qualified import:

```
import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.publicapi.IdCheckWrapperConfigKey
```

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [x] Self-review code
