### PR TITLE
fix: Update to latest version of mobile-ui

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ testparameterinjector = "1.18"
 turbine = "1.2.1"
 uk-gov-logging = "0.32.2" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.7.2"
-uk-gov-ui = "8.3.0"
+uk-gov-ui = "8.5.0"
 gov-uk-idcheck = "0.27.5"
 
 [libraries]


### PR DESCRIPTION
[Tutorial for writing good descriptions]: https://cbea.ms/git-commit/

[//]: # (Be mindful that the PR title also needs to follow conventional commit standards)

# DCMAW-14760: Update to latest version of mobile-ui (8.5.0)

- an internal change to the FullScreenDialogue (a change to the TopAppBar) is now creating the app to crash if using an older version of mobile-ui when used in V2 integration

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change

N/a - no functional change 

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [x] Check against acceptance criteria
- [x] Add automated tests
- [x] Self-review code
