### PR TITLE
ci: Ungroup dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,10 +26,9 @@ updates:
           - "patch"
   - package-ecosystem: "gradle"
     directory: "/"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     schedule:
-      # Check version catalog updates weekly
-      interval: "weekly"
+      interval: "daily"
     registries:
       - github-maven
     commit-message:
@@ -47,10 +46,6 @@ updates:
       govuk:
         patterns:
           - "uk.gov*"
-      gradle:
-        update-types:
-          - "minor"
-          - "patch"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Changes

* Ungroup the catch-all for Gradle Dependabot updates
* Increase the Dependabot PR limit to account for the increase in expected update PRs
* Check for Gradle dependency updates daily

## Context

Grouped dependabot updates tend to fail when a single dependency is incompatible.

For example:
- https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/499
- https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/492
- https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/501

## Evidence of the change

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
