### PR TITLE
feat: Update ID Check SDK from 0.35.15 to 0.37.0

### DIFF
--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/activity/IdCheckSdkActivityParameters.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/activity/IdCheckSdkActivityParameters.kt
@@ -15,5 +15,6 @@ internal fun LauncherData.toIdCheckSdkActivityParameters() =
                 backendMode = this.backendMode,
                 experimentalComposeNavigation = this.experimentalComposeNavigation,
                 nfcAvailability = this.nfcAvailability,
+                enableExpiredDrivingLicences = this.enableExpiredDrivingLicences,
             ),
     )

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/data/LauncherDataReader.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/data/LauncherDataReader.kt
@@ -36,6 +36,9 @@ class LauncherDataReader(
                 configStore.readSingle(NfcConfigKey.NfcAvailability).value,
             )
 
+        val enableExpiredDrivingLicences: Boolean =
+            configStore.readSingle(SdkConfigKey.EnableExpiredDrivingLicences).value
+
         if (result is BiometricTokenResult.Success) {
             sessionStore.updateToDocumentSelected()
         }
@@ -80,6 +83,7 @@ class LauncherDataReader(
                         backendMode = backendMode,
                         experimentalComposeNavigation = experimentalComposeNavigation,
                         nfcAvailability = nfcAvailability,
+                        enableExpiredDrivingLicences = enableExpiredDrivingLicences,
                     ),
                 )
             }

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/model/LauncherData.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/model/LauncherData.kt
@@ -16,6 +16,7 @@ data class LauncherData(
     val backendMode: BackendMode,
     val experimentalComposeNavigation: Boolean,
     val nfcAvailability: NfcAvailability,
+    val enableExpiredDrivingLicences: Boolean,
 ) {
     companion object;
 

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenManualLauncherContent.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/screen/SyncIdCheckScreenManualLauncherContent.kt
@@ -145,6 +145,7 @@ internal fun PreviewSyncIdCheckManualLauncherContent() {
                     backendMode = BackendMode.V2,
                     experimentalComposeNavigation = false,
                     nfcAvailability = NfcAvailability.Device,
+                    enableExpiredDrivingLicences = false,
                 ),
             exitStateOptions = ExitStateOption.entries.map { it.displayName }.toPersistentList(),
             selectedExitState = 0,

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/data/LauncherDataReaderTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/data/LauncherDataReaderTest.kt
@@ -59,6 +59,11 @@ class LauncherDataReaderTest {
                         value =
                             Config.Value.StringValue(NfcConfigKey.NfcAvailability.OPTION_DEVICE),
                     ),
+                    Config.Entry<Config.Value.BooleanValue>(
+                        key = SdkConfigKey.EnableExpiredDrivingLicences,
+                        value =
+                            Config.Value.BooleanValue(false),
+                    ),
                 ),
         )
     private val configStore by lazy {
@@ -81,6 +86,7 @@ class LauncherDataReaderTest {
                     backendMode = BackendMode.V2,
                     experimentalComposeNavigation = false,
                     nfcAvailability = NfcAvailability.Device,
+                    enableExpiredDrivingLicences = false,
                 ),
             )
 
@@ -163,6 +169,39 @@ class LauncherDataReaderTest {
                     launcherData =
                         expectedLauncherDataResult.launcherData.copy(
                             backendMode = BackendMode.Bypass,
+                        ),
+                ),
+                launcherDataResult,
+            )
+        }
+
+    @Test
+    fun `given different expired driving licences config, read gets the launcher data`() =
+        runTest {
+            initialConfig =
+                initialConfig.combinedWith(
+                    Config(
+                        entries =
+                            persistentListOf(
+                                Config.Entry<Config.Value.BooleanValue>(
+                                    key = SdkConfigKey.EnableExpiredDrivingLicences,
+                                    value = Config.Value.BooleanValue(true),
+                                ),
+                            ),
+                    ),
+                )
+
+            val launcherDataReader = createLauncherDataReader()
+            val launcherDataResult =
+                launcherDataReader.read(
+                    documentVariety = documentVariety,
+                )
+
+            assertEquals(
+                expectedLauncherDataResult.copy(
+                    launcherData =
+                        expectedLauncherDataResult.launcherData.copy(
+                            enableExpiredDrivingLicences = true,
                         ),
                 ),
                 launcherDataResult,

--- a/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/config/StubIdCheckWrapperConfig.kt
+++ b/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/config/StubIdCheckWrapperConfig.kt
@@ -10,6 +10,7 @@ fun Config.Companion.createTestInstance(
     enableManualLauncher: Boolean = false,
     bypassIdCheckAsyncBackend: Boolean = false,
     experimentalComposeNavigation: Boolean = false,
+    enableExpiredDrivingLicences: Boolean = false,
 ): Config =
     Config(
         entries =
@@ -29,6 +30,10 @@ fun Config.Companion.createTestInstance(
                 Config.Entry<Config.Value.StringValue>(
                     key = NfcConfigKey.NfcAvailability,
                     value = Config.Value.StringValue(NfcConfigKey.NfcAvailability.OPTION_DEVICE),
+                ),
+                Config.Entry<Config.Value.BooleanValue>(
+                    key = SdkConfigKey.EnableExpiredDrivingLicences,
+                    value = Config.Value.BooleanValue(enableExpiredDrivingLicences),
                 ),
             ),
     )

--- a/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/model/StubLauncherData.kt
+++ b/features/id-check-wrapper/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/model/StubLauncherData.kt
@@ -20,4 +20,5 @@ fun LauncherData.Companion.createTestInstance(
     backendMode = BackendMode.V2,
     experimentalComposeNavigation = experimentalComposeNavigation,
     nfcAvailability = NfcAvailability.Device,
+    enableExpiredDrivingLicences = false,
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ turbine = "1.2.1"
 uk-gov-logging = "0.39.9" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.11.0"
 uk-gov-ui = "16.3.0"
-gov-uk-idcheck = "0.35.15" # https://github.com/govuk-one-login/mobile-id-check-android-sdk/releases
+gov-uk-idcheck = "0.37.0" # https://github.com/govuk-one-login/mobile-id-check-android-sdk/releases
 
 [libraries]
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }


### PR DESCRIPTION
## Change

- Update ID Check SDK from 0.35.15 to 0.37.0
- Wire expired driving licences config (#757) into ID Check SDK

## Context

DCMAW-17989

## Evidence of the change

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
