### PR TITLE
ci: Fix Sonar failure on the `main` branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,25 +43,38 @@ jobs:
       - name: Cache mobile-android-pipelines build
         uses: ./actions/cache-pipelines-build
 
+      - name: Get version
+        id: versioning
+        uses: ./mobile-android-pipelines/actions/increment-version
+        with:
+          dry-run: true
+
       - name: Unit test
         id: unit-tests
         # Exclude Konsist unit tests which are actually lint checks
         # Build all unit tests so that jars are available for Sonar
+        # Provide a version number so that Sonar can find jars that include the version in the name
         run: |
-          ./gradlew assembleDebugUnitTest
-          ./gradlew testDebugUnitTest -x konsist-test:testDebugUnitTest
-          ./gradlew testBuildDebugUnitTest
+          ./gradlew \
+              assembleDebugUnitTest \
+              testDebugUnitTest -x konsist-test:testDebugUnitTest \
+              testBuildDebugUnitTest \
+              -PversionName="$VERSION_NAME"
         env:
           GITHUB_ACTOR: ${{ secrets.MODULE_FETCH_TOKEN_USERNAME }}
           GITHUB_TOKEN: ${{ secrets.MODULE_FETCH_TOKEN }}
+          VERSION_NAME: ${{ github.ref == 'refs/heads/main' && steps.versioning.outputs.new_version || '' }}
 
       - name: Verify screenshots
         run: |
-          ./gradlew verifyPaparazziDebug
-          ./gradlew verifyPaparazziBuildDebug
+          ./gradlew \
+              verifyPaparazziDebug \
+              verifyPaparazziBuildDebug \
+              -PversionName="$VERSION_NAME"
         env:
           GITHUB_ACTOR: ${{ secrets.MODULE_FETCH_TOKEN_USERNAME }}
           GITHUB_TOKEN: ${{ secrets.MODULE_FETCH_TOKEN }}
+          VERSION_NAME: ${{ github.ref == 'refs/heads/main' && steps.versioning.outputs.new_version || '' }}
 
       - name: Upload test report
         if: ${{ failure() && steps.unit-tests.outcome == 'failure' }}


### PR DESCRIPTION
## Context

DCMAW-19659

Resolves Sonar failures on the main branch.

Sonar can't find jars by file name if they were built using a default version number.

Example failed test run: https://github.com/govuk-one-login/mobile-android-cri-orchestrator/actions/runs/24179573943

```
* What went wrong:
Execution failed for task ':libraries:android-utils:sonarResolver'.
...
         > File/directory does not exist: /home/runner/work/mobile-android-cri-orchestrator/mobile-android-cri-orchestrator/libraries/di/build/libs/di-0.64.0.jar
```


## Evidence of the change

I've run the tasks manually, with `-PversionNumber` and verified that the resulting jars have the expected version number:

```sh
$ ./gradlew assembleDebugUnitTest -PversionName="1.2.3"
$ find . -name "*.jar" | grep "libs/di"

./libraries/di/build/libs/di-1.2.3.jar
```

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
