### PR TITLE
feat: Enable expired driving licence content by default

### DIFF
--- a/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/config/DefaultConfig.kt
+++ b/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/config/DefaultConfig.kt
@@ -40,7 +40,7 @@ private val defaultConfig =
                 ),
                 Config.Entry<Config.Value.BooleanValue>(
                     key = SdkConfigKey.EnableExpiredDrivingLicences,
-                    Config.Value.BooleanValue(false),
+                    Config.Value.BooleanValue(true),
                 ),
             ),
     )

--- a/sdk/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/CriOrchestratorSingletonImplTest.kt
+++ b/sdk/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/CriOrchestratorSingletonImplTest.kt
@@ -80,7 +80,7 @@ class CriOrchestratorSingletonImplTest {
                             ),
                             Config.Entry<Config.Value.BooleanValue>(
                                 key = SdkConfigKey.EnableExpiredDrivingLicences,
-                                Config.Value.BooleanValue(false),
+                                Config.Value.BooleanValue(true),
                             ),
                             customEntry,
                         ),


### PR DESCRIPTION
## Changes

Enable expired driving licence content by default.

## Context

DCMAW-19769

The configuration option will be completely removed in a later PR (DCMAW-19602).

## Evidence of the change


<img width="50%" height="2400" alt="image" src="https://github.com/user-attachments/assets/caf9124f-1e8a-48c0-aacd-013a79ffa61d" />

## Checklist

- [x] Check against acceptance criteria
- [x] Add automated tests
- [x] Self-review code
