### PR TITLE
build: DCMAW-17339 Bump ID Check SDK version to 0.37.4

### DIFF
--- a/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityRoot.kt
+++ b/features/resume/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/resume/internal/root/ProveYourIdentityRoot.kt
@@ -44,7 +44,9 @@ internal fun ProveYourIdentityRoot(
                 }.collect {
                     when (it) {
                         ProveYourIdentityRootUiAction.AllowModalToShow ->
-                            navController.navigate(DESTINATION_MODAL)
+                            navController.navigate(DESTINATION_MODAL) {
+                                launchSingleTop = true
+                            }
                     }
                 }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ turbine = "1.2.1"
 uk-gov-logging = "0.39.9" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.11.0"
 uk-gov-ui = "16.4.0"
-gov-uk-idcheck = "0.37.0" # https://github.com/govuk-one-login/mobile-id-check-android-sdk/releases
+gov-uk-idcheck = "0.37.4" # https://github.com/govuk-one-login/mobile-id-check-android-sdk/releases
 
 [libraries]
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }


### PR DESCRIPTION
[Tutorial for writing good descriptions]: https://cbea.ms/git-commit/

[//]: # (Be mindful that the PR title also needs to follow conventional commit standards)

# DCMAW-17339: Update ID Check SDK version to 0.37.4

- Updated ID Check SDK from `0.37.0` to `0.37.4` to get the new `ConfirmAnotherWayHostDialogFragment` which adds a close button to the `confirm your identity another way` flow screens
- Added `launchSingleTop = true` to the `AllowModalToShow` navigation in `ProveYourIdentityRoot`
  - This resolves a bug when the device is rotated on the first abort screen inside the ID Check SDK, the activity recreation causes `AllowModalToShow` to re-trigger, which was adding a duplicate /modal onto the navigation back stack. This results in the user needing to press the X button twice to close the second abort screen (AbortedReturnToDesktopWeb).

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change
[//]: # (Screenshots / uploaded videos go here)

[DAD-Light-Theme.webm](https://github.com/user-attachments/assets/561d9b5e-c651-46f2-b002-b48866bb48e3)

[MAM-Dark-Theme.webm](https://github.com/user-attachments/assets/f343d08d-12f3-41a5-8843-80a0d657a6dc)


## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code