### PR TITLE
feat: DCMAW-20156 Bump ID Check SDK version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ turbine = "1.2.1"
 uk-gov-logging = "0.39.15" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.11.0"
 uk-gov-ui = "16.7.0"
-gov-uk-idcheck = "0.41.3" # https://github.com/govuk-one-login/mobile-id-check-android-sdk/releases
+gov-uk-idcheck = "0.41.4" # https://github.com/govuk-one-login/mobile-id-check-android-sdk/releases
 
 [libraries]
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }


### PR DESCRIPTION
# DCMAW-20156: User unable to progress down the unhappy path after closing 'Check if you can prove your identity another way' overlay

- Bump ID Check SDK version

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [x] Check against acceptance criteria
- [x] Add automated tests
- [x] Self-review code
