### PR TITLE
feat: DCMAW-20416 Migrate from GenericHttpClient to NetworkService 

### DIFF
--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApi.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApi.kt
@@ -1,11 +1,12 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken
 
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.NetworkingException
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 
 fun interface BiometricApi {
     suspend fun getBiometricToken(
         sessionId: String,
         documentVariety: DocumentVariety,
-    ): ApiResponse
+    ): ApiResponse<String, NetworkingException>
 }

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImpl.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImpl.kt
@@ -1,22 +1,22 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken
 
 import dev.zacsweers.metro.Inject
-import uk.gov.android.network.api.ApiRequest
 import uk.gov.android.network.api.ApiResponse
-import uk.gov.android.network.client.ContentType
-import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.service.NetworkService
 import uk.gov.logging.api.LogTagProvider
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey.IdCheckAsyncBackendBaseUrl
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.data.BiometricApiRequest.BiometricRequest
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.nav.toDocumentType
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
+import uk.gov.android.network.api.v2.ApiResponse as ApiResponseV2
 
 private const val BIOMETRIC_TOKEN_ENDPOINT = "/async/biometricToken"
 
 @Inject
 class BiometricApiImpl(
-    private val httpClient: GenericHttpClient,
+    private val networkService: NetworkService,
     private val configStore: ConfigStore,
 ) : BiometricApi,
     LogTagProvider {
@@ -32,11 +32,15 @@ class BiometricApiImpl(
                         sessionId,
                         documentVariety.toDocumentType().backendRepresentation,
                     ),
-                contentType = ContentType.APPLICATION_JSON,
+                headers = listOf("content-type" to "application/json"),
             )
 
-        return httpClient.makeRequest(
-            apiRequest = request,
-        )
+        return when (val response = networkService.makeRequest(request)) {
+            is ApiResponseV2.Success -> ApiResponse.Success(response.response)
+            is ApiResponseV2.Failure -> ApiResponse.Failure(
+                status = response.status ?: 0,
+                error = response.error,
+            )
+        }
     }
 }

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImpl.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImpl.kt
@@ -1,16 +1,16 @@
 package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken
 
 import dev.zacsweers.metro.Inject
-import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.api.v2.ApiResponse
 import uk.gov.android.network.service.NetworkService
+import uk.gov.android.network.service.NetworkingException
 import uk.gov.logging.api.LogTagProvider
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey.IdCheckAsyncBackendBaseUrl
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.data.BiometricApiRequest.BiometricRequest
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.nav.toDocumentType
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
-import uk.gov.android.network.api.v2.ApiResponse as ApiResponseV2
 
 private const val BIOMETRIC_TOKEN_ENDPOINT = "/async/biometricToken"
 
@@ -23,7 +23,7 @@ class BiometricApiImpl(
     override suspend fun getBiometricToken(
         sessionId: String,
         documentVariety: DocumentVariety,
-    ): ApiResponse {
+    ): ApiResponse<String, NetworkingException> {
         val request =
             ApiRequest.Post(
                 url = "${configStore.readSingle(IdCheckAsyncBackendBaseUrl).value}$BIOMETRIC_TOKEN_ENDPOINT",
@@ -35,12 +35,6 @@ class BiometricApiImpl(
                 headers = listOf("content-type" to "application/json"),
             )
 
-        return when (val response = networkService.makeRequest(request)) {
-            is ApiResponseV2.Success -> ApiResponse.Success(response.response)
-            is ApiResponseV2.Failure -> ApiResponse.Failure(
-                status = response.status ?: 0,
-                error = response.error,
-            )
-        }
+        return networkService.makeRequest(request)
     }
 }

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/FakeBiometricTokenApi.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/FakeBiometricTokenApi.kt
@@ -3,7 +3,8 @@ package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometr
 import dev.zacsweers.metro.Inject
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.NetworkingException
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 
 @Inject
@@ -17,7 +18,7 @@ class FakeBiometricTokenApi : BiometricApi {
     override suspend fun getBiometricToken(
         sessionId: String,
         documentVariety: DocumentVariety,
-    ): ApiResponse {
+    ): ApiResponse<String, NetworkingException> {
         val response =
             BiometricToken(
                 accessToken = "SlAV32hkKG",
@@ -25,9 +26,7 @@ class FakeBiometricTokenApi : BiometricApi {
             )
         val responseString = json.encodeToString(response)
 
-        return ApiResponse.Success<String>(
-            responseString,
-        )
+        return ApiResponse.Success(response = responseString, status = 200)
     }
 }
 

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/RemoteBiometricTokenReader.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/RemoteBiometricTokenReader.kt
@@ -4,7 +4,8 @@ import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
 import dev.zacsweers.metro.binding
 import kotlinx.serialization.json.Json
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.TransportException
 import uk.gov.idcheck.repositories.api.vendor.BiometricToken
 import uk.gov.logging.api.LogTagProvider
 import uk.gov.logging.api.Logger
@@ -33,25 +34,27 @@ class RemoteBiometricTokenReader(
         val response = biometricApi.getBiometricToken(sessionId, documentVariety)
 
         return when (response) {
-            ApiResponse.Offline -> BiometricTokenResult.Offline
-
             is ApiResponse.Failure -> {
-                logger.error(
-                    tag,
-                    "Failed to get biometric token: ${response.error.message}",
-                    response.error,
-                )
-                BiometricTokenResult.Error(
-                    statusCode = response.status,
-                    error = response.error,
-                )
+                if (response.error is TransportException) {
+                    BiometricTokenResult.Offline
+                } else {
+                    logger.error(
+                        tag,
+                        "Failed to get biometric token: ${response.error.message}",
+                        response.error,
+                    )
+                    BiometricTokenResult.Error(
+                        statusCode = response.status,
+                        error = response.error,
+                    )
+                }
             }
 
-            is ApiResponse.Success<*> -> {
+            is ApiResponse.Success -> {
                 try {
                     val parsedResponse =
                         json.decodeFromString<BiometricApiResponse.BiometricSuccess>(
-                            response.response.toString(),
+                            response.response,
                         )
 
                     logger.debug(tag, "Got the biometric token")
@@ -69,11 +72,6 @@ class RemoteBiometricTokenReader(
                     )
                 }
             }
-
-            ApiResponse.Loading ->
-                BiometricTokenResult.Error(
-                    error = IllegalStateException("Loading state should not be returned"),
-                )
         }
     }
 }

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/RemoteBiometricTokenReader.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/RemoteBiometricTokenReader.kt
@@ -3,6 +3,7 @@ package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometr
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
 import dev.zacsweers.metro.binding
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.json.Json
 import uk.gov.android.network.api.v2.ApiResponse
 import uk.gov.android.network.service.TransportException
@@ -31,7 +32,15 @@ class RemoteBiometricTokenReader(
         sessionId: String,
         documentVariety: DocumentVariety,
     ): BiometricTokenResult {
-        val response = biometricApi.getBiometricToken(sessionId, documentVariety)
+        val response =
+            try {
+                biometricApi.getBiometricToken(sessionId, documentVariety)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.error(tag, "Failed to get biometric token: ${e.message}", e)
+                return BiometricTokenResult.Error(error = e)
+            }
 
         return when (response) {
             is ApiResponse.Failure -> {

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/RemoteBiometricTokenReader.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/RemoteBiometricTokenReader.kt
@@ -3,7 +3,6 @@ package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometr
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
 import dev.zacsweers.metro.binding
-import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.json.Json
 import uk.gov.android.network.api.v2.ApiResponse
 import uk.gov.android.network.service.TransportException
@@ -14,9 +13,11 @@ import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometri
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.data.ConfigurableBiometricApi
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internalapi.DocumentVariety
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
+import kotlin.coroutines.cancellation.CancellationException
 
 @SingleIn(CriOrchestratorScope::class)
 @ContributesBinding(CriOrchestratorScope::class, binding = binding<BiometricTokenReader>())
+@Suppress("TooGenericExceptionCaught")
 class RemoteBiometricTokenReader(
     private val biometricApi: ConfigurableBiometricApi,
     private val logger: Logger,

--- a/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/data/ConfigurableBiometricApi.kt
+++ b/features/id-check-wrapper/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/data/ConfigurableBiometricApi.kt
@@ -3,7 +3,8 @@ package uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometr
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Provider
 import dev.zacsweers.metro.binding
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.NetworkingException
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.BiometricApi
@@ -21,7 +22,7 @@ class ConfigurableBiometricApi(
     override suspend fun getBiometricToken(
         sessionId: String,
         documentVariety: DocumentVariety,
-    ): ApiResponse =
+    ): ApiResponse<String, NetworkingException> =
         if (configStore.readSingle(SdkConfigKey.BypassIdCheckAsyncBackend).value) {
             fakeBiometricApi().getBiometricToken(sessionId, documentVariety)
         } else {

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImplTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImplTest.kt
@@ -11,8 +11,8 @@ import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.api.v2.ApiResponse
 import uk.gov.android.network.service.NetworkService
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.FakeConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
@@ -23,7 +23,6 @@ import uk.gov.onelogin.criorchestrator.libraries.testing.networking.Imposter
 import uk.gov.onelogin.criorchestrator.libraries.testing.networking.createTestHttpClient
 import java.util.stream.Stream
 import kotlin.test.assertEquals
-import uk.gov.android.network.api.v2.ApiResponse as ApiResponseV2
 
 class BiometricApiImplTest {
     private lateinit var biometricApiImpl: BiometricApi
@@ -54,14 +53,13 @@ class BiometricApiImplTest {
     @Test
     fun `biometric API implementation returns stubbed response`() =
         runTest {
-            val expected =
-                ApiResponse.Success<String>(
-                    "{\"accessToken\":\"string\",\"opaqueId\":\"6ec96ea7-941c-4967-9fcf-94fc9b717a22\"}",
-                )
-
             val result =
                 biometricApiImpl.getBiometricToken("sessionId", DocumentVariety.NFC_PASSPORT)
-            assertEquals(expected, result)
+            val success = result as ApiResponse.Success
+            assertEquals(
+                "{\"accessToken\":\"string\",\"opaqueId\":\"6ec96ea7-941c-4967-9fcf-94fc9b717a22\"}",
+                success.response,
+            )
         }
 
     @ParameterizedTest(name = "{0}")
@@ -80,7 +78,7 @@ class BiometricApiImplTest {
             whenever(
                 mockHttpClient.makeRequest(any(), any()),
             ).thenReturn(
-                ApiResponseV2.Success(
+                ApiResponse.Success(
                     response = "{\"accessToken\":\"string\",\"opaqueId\":\"6ec96ea7-941c-4967-9fcf-94fc9b717a22\"}",
                     status = 200,
                 ),

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImplTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/BiometricApiImplTest.kt
@@ -11,10 +11,9 @@ import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.android.network.api.ApiRequest
 import uk.gov.android.network.api.ApiResponse
-import uk.gov.android.network.client.ContentType
-import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.service.NetworkService
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.FakeConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey.IdCheckAsyncBackendBaseUrl
@@ -24,6 +23,7 @@ import uk.gov.onelogin.criorchestrator.libraries.testing.networking.Imposter
 import uk.gov.onelogin.criorchestrator.libraries.testing.networking.createTestHttpClient
 import java.util.stream.Stream
 import kotlin.test.assertEquals
+import uk.gov.android.network.api.v2.ApiResponse as ApiResponseV2
 
 class BiometricApiImplTest {
     private lateinit var biometricApiImpl: BiometricApi
@@ -46,7 +46,7 @@ class BiometricApiImplTest {
 
         biometricApiImpl =
             BiometricApiImpl(
-                httpClient = createTestHttpClient(),
+                networkService = createTestHttpClient(),
                 configStore = fakeConfigStore,
             )
     }
@@ -70,18 +70,19 @@ class BiometricApiImplTest {
         expectedDocumentString: String,
         documentVariety: DocumentVariety,
     ) {
-        val mockHttpClient: GenericHttpClient = mock()
+        val mockHttpClient: NetworkService = mock()
         biometricApiImpl =
             BiometricApiImpl(
-                httpClient = mockHttpClient,
+                networkService = mockHttpClient,
                 configStore = fakeConfigStore,
             )
         runTest {
             whenever(
-                mockHttpClient.makeRequest(any()),
+                mockHttpClient.makeRequest(any(), any()),
             ).thenReturn(
-                ApiResponse.Success<String>(
-                    "{\"accessToken\":\"string\",\"opaqueId\":\"6ec96ea7-941c-4967-9fcf-94fc9b717a22\"}",
+                ApiResponseV2.Success(
+                    response = "{\"accessToken\":\"string\",\"opaqueId\":\"6ec96ea7-941c-4967-9fcf-94fc9b717a22\"}",
+                    status = 200,
                 ),
             )
             biometricApiImpl.getBiometricToken("sessionId", documentVariety)
@@ -96,7 +97,7 @@ class BiometricApiImplTest {
                             "sessionId",
                             expectedDocumentString,
                         ),
-                    contentType = ContentType.APPLICATION_JSON,
+                    headers = listOf("content-type" to "application/json"),
                 ),
             )
         }

--- a/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/RemoteBiometricTokenReaderTest.kt
+++ b/features/id-check-wrapper/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/idcheckwrapper/internal/biometrictoken/RemoteBiometricTokenReaderTest.kt
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.ApiResponseException
+import uk.gov.android.network.service.TransportException
 import uk.gov.logging.api.Logger
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.data.BiometricApiResponse
 import uk.gov.onelogin.criorchestrator.features.idcheckwrapper.internal.biometrictoken.data.ConfigurableBiometricApi
@@ -32,32 +34,12 @@ class RemoteBiometricTokenReaderTest {
     }
 
     @Test
-    fun `emits error when api response is loading`() =
+    fun `emits offline when api response is a transport failure`() =
         runTest {
             whenever(
-                biometricApi.getBiometricToken(
-                    SESSION_ID,
-                    documentType,
-                ),
+                biometricApi.getBiometricToken(SESSION_ID, documentType),
             ).thenReturn(
-                ApiResponse.Loading,
-            )
-
-            val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
-
-            assert(result is BiometricTokenResult.Error)
-        }
-
-    @Test
-    fun `emits error when api response is offline`() =
-        runTest {
-            whenever(
-                biometricApi.getBiometricToken(
-                    SESSION_ID,
-                    documentType,
-                ),
-            ).thenReturn(
-                ApiResponse.Offline,
+                ApiResponse.Failure(error = TransportException(cause = null)),
             )
 
             val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
@@ -69,11 +51,13 @@ class RemoteBiometricTokenReaderTest {
     fun `emits error when api response is failure`() =
         runTest {
             whenever(
-                biometricApi.getBiometricToken(
-                    SESSION_ID,
-                    documentType,
+                biometricApi.getBiometricToken(SESSION_ID, documentType),
+            ).thenReturn(
+                ApiResponse.Failure(
+                    error = ApiResponseException("error", null),
+                    status = 400,
                 ),
-            ).thenReturn(ApiResponse.Failure(status = 400, error = Exception("error")))
+            )
 
             val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
             val error = result as BiometricTokenResult.Error
@@ -94,11 +78,8 @@ class RemoteBiometricTokenReaderTest {
             val encoded = json.encodeToString(successData)
 
             whenever(
-                biometricApi.getBiometricToken(
-                    SESSION_ID,
-                    documentType,
-                ),
-            ).thenReturn(ApiResponse.Success(encoded))
+                biometricApi.getBiometricToken(SESSION_ID, documentType),
+            ).thenReturn(ApiResponse.Success(response = encoded, status = 200))
 
             val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
 
@@ -109,12 +90,11 @@ class RemoteBiometricTokenReaderTest {
     fun `emits error when api response is success but parsing fails`() =
         runTest {
             whenever(
-                biometricApi.getBiometricToken(
-                    SESSION_ID,
-                    documentType,
-                ),
-            ).thenReturn(ApiResponse.Success("invalid json"))
+                biometricApi.getBiometricToken(SESSION_ID, documentType),
+            ).thenReturn(ApiResponse.Success(response = "invalid json", status = 200))
+
             val result = biometricTokenReader.getBiometricToken(SESSION_ID, documentType)
+
             assert(result is BiometricTokenResult.Error)
         }
 }

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReader.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReader.kt
@@ -5,7 +5,9 @@ import dev.zacsweers.metro.Provider
 import dev.zacsweers.metro.binding
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.serialization.json.Json
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.NetworkingException
+import uk.gov.android.network.service.TransportException
 import uk.gov.logging.api.LogTagProvider
 import uk.gov.logging.api.Logger
 import uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession.ActiveSessionApi
@@ -35,18 +37,17 @@ class RemoteSessionReader(
         logResponse(response)
 
         return when (response) {
-            ApiResponse.Loading,
-            ApiResponse.Offline,
-            -> {
-                return SessionReader.Result.Unknown
-            }
             is ApiResponse.Failure -> {
-                when (response.status) {
-                    NOT_FOUND -> SessionReader.Result.IsNotActive
-                    else -> SessionReader.Result.Unknown
+                if (response.error is TransportException) {
+                    SessionReader.Result.Unknown
+                } else {
+                    when (response.status) {
+                        NOT_FOUND -> SessionReader.Result.IsNotActive
+                        else -> SessionReader.Result.Unknown
+                    }
                 }
             }
-            is ApiResponse.Success<*> -> {
+            is ApiResponse.Success -> {
                 val session = parseSession(response)
                 when (session) {
                     null -> SessionReader.Result.Unknown
@@ -56,10 +57,10 @@ class RemoteSessionReader(
         }
     }
 
-    private fun parseSession(response: ApiResponse.Success<*>): Session? =
+    private fun parseSession(response: ApiResponse.Success<String>): Session? =
         try {
             val parsedResponse: ActiveSessionApiResponse.ActiveSessionSuccess =
-                json.decodeFromString(response.response.toString())
+                json.decodeFromString(response.response)
             Session(
                 sessionId = parsedResponse.sessionId,
                 redirectUri = generateRedirectUri(parsedResponse.redirectUri, parsedResponse.state),
@@ -69,19 +70,22 @@ class RemoteSessionReader(
             null
         }
 
-    private fun logResponse(response: ApiResponse) {
+    private fun logResponse(response: ApiResponse<String, NetworkingException>) {
         when (response) {
-            is ApiResponse.Success<*> ->
+            is ApiResponse.Success ->
                 logger.debug(tag, "Got active session")
 
-            is ApiResponse.Failure ->
-                logger.error(tag, "Failed to fetch active session", response.error)
-
-            ApiResponse.Loading ->
-                logger.debug(tag, "Loading ... fetching active session ...")
-
-            ApiResponse.Offline ->
-                logger.debug(tag, "Failed to fetch active session - device is offline")
+            is ApiResponse.Failure -> {
+                if (response.error is TransportException) {
+                    logger.debug(tag, "Failed to fetch active session - device is offline")
+                } else {
+                    logger.error(
+                        tag,
+                        "Failed to fetch active session",
+                        response.error,
+                    )
+                }
+            }
         }
     }
 

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/AbortSessionApi.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/AbortSessionApi.kt
@@ -1,7 +1,8 @@
 package uk.gov.onelogin.criorchestrator.features.session.internal.network.abort
 
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.NetworkingException
 
 fun interface AbortSessionApi {
-    suspend fun abortSession(sessionId: String): ApiResponse
+    suspend fun abortSession(sessionId: String): ApiResponse<String, NetworkingException>
 }

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/AbortSessionApiImpl.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/AbortSessionApiImpl.kt
@@ -1,7 +1,8 @@
 package uk.gov.onelogin.criorchestrator.features.session.internal.network.abort
 
 import dev.zacsweers.metro.ContributesBinding
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.NetworkingException
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorScope
@@ -12,7 +13,7 @@ class AbortSessionApiImpl(
     private val realAbortSessionApi: RealAbortSessionApi,
     private val fakeAbortSessionApi: FakeAbortSessionApi,
 ) : AbortSessionApi {
-    override suspend fun abortSession(sessionId: String): ApiResponse =
+    override suspend fun abortSession(sessionId: String): ApiResponse<String, NetworkingException> =
         if (config.readSingle(SdkConfigKey.BypassIdCheckAsyncBackend).value) {
             fakeAbortSessionApi
         } else {

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/FakeAbortSessionApi.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/FakeAbortSessionApi.kt
@@ -3,7 +3,10 @@ package uk.gov.onelogin.criorchestrator.features.session.internal.network.abort
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.ApiResponseException
+import uk.gov.android.network.service.NetworkingException
+import uk.gov.android.network.service.TransportException
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
 import uk.gov.onelogin.criorchestrator.libraries.kotlinutils.CoroutineDispatchers
@@ -16,16 +19,20 @@ class FakeAbortSessionApi(
     private val configStore: ConfigStore,
     private val coroutineDispatchers: CoroutineDispatchers,
 ) : AbortSessionApi {
-    override suspend fun abortSession(sessionId: String): ApiResponse =
+    override suspend fun abortSession(sessionId: String): ApiResponse<String, NetworkingException> =
         withContext(coroutineDispatchers.io) {
             delay(DELAY)
             when (configStore.readSingle(SdkConfigKey.BypassAbortSessionApiCall).value) {
-                SdkConfigKey.BypassAbortSessionApiCall.OPTION_SUCCESS -> ApiResponse.Success<String>("")
-                SdkConfigKey.BypassAbortSessionApiCall.OPTION_OFFLINE -> ApiResponse.Offline
+                SdkConfigKey.BypassAbortSessionApiCall.OPTION_SUCCESS ->
+                    ApiResponse.Success(response = "", status = 200)
+
+                SdkConfigKey.BypassAbortSessionApiCall.OPTION_OFFLINE ->
+                    ApiResponse.Failure(error = TransportException(cause = null))
+
                 SdkConfigKey.BypassAbortSessionApiCall.OPTION_UNRECOVERABLE_ERROR ->
                     ApiResponse.Failure(
-                        BAD_REQUEST,
-                        Exception("Simulated exception"),
+                        error = ApiResponseException("Simulated exception", null),
+                        status = BAD_REQUEST,
                     )
 
                 else -> error("Unknown bypass abort session API call result configuration")

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/RealAbortSessionApi.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/RealAbortSessionApi.kt
@@ -2,13 +2,13 @@ package uk.gov.onelogin.criorchestrator.features.session.internal.network.abort
 
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.first
-import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.api.v2.ApiResponse
 import uk.gov.android.network.service.NetworkService
+import uk.gov.android.network.service.NetworkingException
 import uk.gov.logging.api.LogTagProvider
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey.IdCheckAsyncBackendBaseUrl
-import uk.gov.android.network.api.v2.ApiResponse as ApiResponseV2
 
 private const val ABORT_SESSION_ENDPOINT = "/async/abortSession"
 
@@ -18,7 +18,7 @@ class RealAbortSessionApi(
     private val configStore: ConfigStore,
 ) : AbortSessionApi,
     LogTagProvider {
-    override suspend fun abortSession(sessionId: String): ApiResponse {
+    override suspend fun abortSession(sessionId: String): ApiResponse<String, NetworkingException> {
         val baseUrl = configStore.read(IdCheckAsyncBackendBaseUrl).first().value
         val request =
             ApiRequest.Post(
@@ -29,12 +29,6 @@ class RealAbortSessionApi(
                     ),
                 headers = listOf("content-type" to "application/json"),
             )
-        return when (val response = networkService.makeRequest(request)) {
-            is ApiResponseV2.Success -> ApiResponse.Success(response.response)
-            is ApiResponseV2.Failure -> ApiResponse.Failure(
-                status = response.status ?: 0,
-                error = response.error,
-            )
-        }
+        return networkService.makeRequest(request)
     }
 }

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/RealAbortSessionApi.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/RealAbortSessionApi.kt
@@ -2,19 +2,19 @@ package uk.gov.onelogin.criorchestrator.features.session.internal.network.abort
 
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.first
-import uk.gov.android.network.api.ApiRequest
 import uk.gov.android.network.api.ApiResponse
-import uk.gov.android.network.client.ContentType
-import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.service.NetworkService
 import uk.gov.logging.api.LogTagProvider
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey.IdCheckAsyncBackendBaseUrl
+import uk.gov.android.network.api.v2.ApiResponse as ApiResponseV2
 
 private const val ABORT_SESSION_ENDPOINT = "/async/abortSession"
 
 @Inject
 class RealAbortSessionApi(
-    private val httpClient: GenericHttpClient,
+    private val networkService: NetworkService,
     private val configStore: ConfigStore,
 ) : AbortSessionApi,
     LogTagProvider {
@@ -27,10 +27,14 @@ class RealAbortSessionApi(
                     AbortSessionApiRequest(
                         sessionId = sessionId,
                     ),
-                contentType = ContentType.APPLICATION_JSON,
+                headers = listOf("content-type" to "application/json"),
             )
-        return httpClient.makeRequest(
-            apiRequest = request,
-        )
+        return when (val response = networkService.makeRequest(request)) {
+            is ApiResponseV2.Success -> ApiResponse.Success(response.response)
+            is ApiResponseV2.Failure -> ApiResponse.Failure(
+                status = response.status ?: 0,
+                error = response.error,
+            )
+        }
     }
 }

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApi.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApi.kt
@@ -1,6 +1,7 @@
 package uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession
 
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.NetworkingException
 
 /**
  * The ID Check async backend's 'active session' API.
@@ -17,5 +18,5 @@ fun interface ActiveSessionApi {
      * - the user hasn't selected a document, and
      * - the user hasn't aborted the session
      */
-    suspend fun getActiveSession(): ApiResponse
+    suspend fun getActiveSession(): ApiResponse<String, NetworkingException>
 }

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiImpl.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiImpl.kt
@@ -2,13 +2,13 @@ package uk.gov.onelogin.criorchestrator.features.session.internal.network.active
 
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.first
-import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.api.v2.ApiResponse
 import uk.gov.android.network.service.NetworkService
+import uk.gov.android.network.service.NetworkingException
 import uk.gov.logging.api.LogTagProvider
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
-import uk.gov.android.network.api.v2.ApiResponse as ApiResponseV2
 
 private const val GET_ACTIVE_SESSION_ENDPOINT = "/async/activeSession"
 
@@ -18,20 +18,14 @@ class ActiveSessionApiImpl(
     private val configStore: ConfigStore,
 ) : ActiveSessionApi,
     LogTagProvider {
-    override suspend fun getActiveSession(): ApiResponse {
+    override suspend fun getActiveSession(): ApiResponse<String, NetworkingException> {
         val baseUrl = configStore.read(SdkConfigKey.IdCheckAsyncBackendBaseUrl).first().value
         val request =
             ApiRequest.Get(
                 url = baseUrl + GET_ACTIVE_SESSION_ENDPOINT,
             )
-        return when (val response = networkService.makeRequest(request) {
+        return networkService.makeRequest(request) {
             withAuthentication(SCOPE)
-        }) {
-            is ApiResponseV2.Success -> ApiResponse.Success(response.response)
-            is ApiResponseV2.Failure -> ApiResponse.Failure(
-                status = response.status ?: 0,
-                error = response.error,
-            )
         }
     }
 

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiImpl.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiImpl.kt
@@ -2,18 +2,19 @@ package uk.gov.onelogin.criorchestrator.features.session.internal.network.active
 
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.first
-import uk.gov.android.network.api.ApiRequest
 import uk.gov.android.network.api.ApiResponse
-import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.service.NetworkService
 import uk.gov.logging.api.LogTagProvider
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
+import uk.gov.android.network.api.v2.ApiResponse as ApiResponseV2
 
 private const val GET_ACTIVE_SESSION_ENDPOINT = "/async/activeSession"
 
 @Inject
 class ActiveSessionApiImpl(
-    private val httpClient: GenericHttpClient,
+    private val networkService: NetworkService,
     private val configStore: ConfigStore,
 ) : ActiveSessionApi,
     LogTagProvider {
@@ -23,10 +24,15 @@ class ActiveSessionApiImpl(
             ApiRequest.Get(
                 url = baseUrl + GET_ACTIVE_SESSION_ENDPOINT,
             )
-        return httpClient.makeAuthorisedRequest(
-            apiRequest = request,
-            scope = SCOPE,
-        )
+        return when (val response = networkService.makeRequest(request) {
+            withAuthentication(SCOPE)
+        }) {
+            is ApiResponseV2.Success -> ApiResponse.Success(response.response)
+            is ApiResponseV2.Failure -> ApiResponse.Failure(
+                status = response.status ?: 0,
+                error = response.error,
+            )
+        }
     }
 
     companion object {

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ConfigurableActiveSessionApi.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ConfigurableActiveSessionApi.kt
@@ -3,7 +3,8 @@ package uk.gov.onelogin.criorchestrator.features.session.internal.network.active
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Provider
 import dev.zacsweers.metro.binding
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.NetworkingException
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
 import uk.gov.onelogin.criorchestrator.libraries.di.CriOrchestratorAppScope
@@ -14,7 +15,7 @@ class ConfigurableActiveSessionApi(
     private val realActiveSessionApi: Provider<ActiveSessionApiImpl>,
     private val fakeActiveSessionApi: Provider<FakeActiveSessionApi>,
 ) : ActiveSessionApi {
-    override suspend fun getActiveSession(): ApiResponse =
+    override suspend fun getActiveSession(): ApiResponse<String, NetworkingException> =
         if (configStore.readSingle(SdkConfigKey.BypassIdCheckAsyncBackend).value) {
             fakeActiveSessionApi()
         } else {

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/FakeActiveSessionApi.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/FakeActiveSessionApi.kt
@@ -2,7 +2,8 @@ package uk.gov.onelogin.criorchestrator.features.session.internal.network.active
 
 import dev.zacsweers.metro.Inject
 import kotlinx.serialization.json.Json
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.NetworkingException
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.ConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
 
@@ -10,7 +11,7 @@ import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
 class FakeActiveSessionApi(
     private val configStore: ConfigStore,
 ) : ActiveSessionApi {
-    override suspend fun getActiveSession(): ApiResponse {
+    override suspend fun getActiveSession(): ApiResponse<String, NetworkingException> {
         val redirectUri =
             when (configStore.readSingle(SdkConfigKey.BypassJourneyType).value) {
                 SdkConfigKey.BypassJourneyType.OPTION_MOBILE_APP_MOBILE -> "https://example/redirect"
@@ -23,6 +24,6 @@ class FakeActiveSessionApi(
                 redirectUri = redirectUri,
                 state = "11112222333344445555666677778888",
             )
-        return ApiResponse.Success<String>(Json.encodeToString(response))
+        return ApiResponse.Success(response = Json.encodeToString(response), status = 200)
     }
 }

--- a/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/usecases/AbortSessionImpl.kt
+++ b/features/session/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/usecases/AbortSessionImpl.kt
@@ -4,7 +4,8 @@ import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.binding
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.TransportException
 import uk.gov.logging.api.LogTagProvider
 import uk.gov.logging.api.Logger
 import uk.gov.onelogin.criorchestrator.features.session.internal.network.abort.AbortSessionApi
@@ -33,24 +34,28 @@ class AbortSessionImpl(
         val response = abortSessionApi.abortSession(session.sessionId)
 
         when (response) {
-            is ApiResponse.Success<*> ->
+            is ApiResponse.Success ->
                 logger.info(tag, "Aborted session")
 
-            is ApiResponse.Failure ->
-                logger.error(tag, "Failed to abort session", response.error)
-
-            ApiResponse.Loading -> unexpectedLoadingApiResponse()
-
-            ApiResponse.Offline ->
-                logger.debug(tag, "Failed to abort session - device is offline")
+            is ApiResponse.Failure -> {
+                if (response.error is TransportException) {
+                    logger.debug(tag, "Failed to abort session - device is offline")
+                } else {
+                    logger.error(tag, "Failed to abort session", response.error)
+                }
+            }
         }
 
         val result =
             when (response) {
-                is ApiResponse.Failure -> AbortSession.Result.Error.Unrecoverable(response.error)
-                ApiResponse.Offline -> AbortSession.Result.Error.Offline
-                is ApiResponse.Success<*> -> AbortSession.Result.Success
-                ApiResponse.Loading -> unexpectedLoadingApiResponse()
+                is ApiResponse.Failure -> {
+                    if (response.error is TransportException) {
+                        AbortSession.Result.Error.Offline
+                    } else {
+                        AbortSession.Result.Error.Unrecoverable(response.error)
+                    }
+                }
+                is ApiResponse.Success -> AbortSession.Result.Success
             }
 
         when (result) {
@@ -66,9 +71,4 @@ class AbortSessionImpl(
 
         return result
     }
-
-    /**
-     * This should never be called as the networking library doesn't emit loading results.
-     */
-    private fun unexpectedLoadingApiResponse(): Nothing = error("Loading state is not possible")
 }

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/IntegrationTest.kt
@@ -39,7 +39,7 @@ class IntegrationTest {
         )
         activeSessionApi =
             ActiveSessionApiImpl(
-                httpClient = createTestHttpClient(),
+                networkService = createTestHttpClient(),
                 configStore = fakeConfigStore,
             )
 

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/RemoteSessionReaderTest.kt
@@ -15,7 +15,10 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.ApiResponseException
+import uk.gov.android.network.service.NetworkingException
+import uk.gov.android.network.service.TransportException
 import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.Session
 import uk.gov.onelogin.criorchestrator.libraries.androidutils.FakeUriBuilderImpl
@@ -40,13 +43,15 @@ class RemoteSessionReaderTest {
 
     @AfterEach
     fun tearDown() {
-        activeSessionApi.setActiveSession(ApiResponse.Offline)
+        activeSessionApi.setActiveSession(
+            ApiResponse.Failure(error = TransportException(cause = null)),
+        )
     }
 
     @ParameterizedTest(name = "{0} and correctly writes to session store")
     @MethodSource("assertCorrectApiResponseHandling")
     fun `session reader returns `(
-        apiResponse: ApiResponse,
+        apiResponse: ApiResponse<String, NetworkingException>,
         logEntry: String,
         expectedResult: SessionReader.Result,
     ) = runTest {
@@ -72,8 +77,8 @@ class RemoteSessionReaderTest {
                     named(
                         "false with expected log entry when API response is Failure",
                         ApiResponse.Failure(
+                            error = ApiResponseException("test exception", null),
                             status = 401,
-                            error = Exception("test exception"),
                         ),
                     ),
                     "Failed to fetch active session",
@@ -83,8 +88,8 @@ class RemoteSessionReaderTest {
                     named(
                         "false with expected log entry when API response is 404 not found",
                         ApiResponse.Failure(
+                            error = ApiResponseException("test exception", null),
                             status = 404,
-                            error = Exception("test exception"),
                         ),
                     ),
                     "Failed to fetch active session",
@@ -92,17 +97,10 @@ class RemoteSessionReaderTest {
                 ),
                 arguments(
                     named(
-                        "false with expected log entry when API response is Loading",
-                        ApiResponse.Loading,
-                    ),
-                    "Loading ... fetching active session ...",
-                    SessionReader.Result.Unknown,
-                    null,
-                ),
-                arguments(
-                    named(
-                        "false with expected log entry when API response is Offline",
-                        ApiResponse.Offline,
+                        "false with expected log entry when API response is a transport failure (offline)",
+                        ApiResponse.Failure(
+                            error = TransportException(cause = null),
+                        ),
                     ),
                     "Failed to fetch active session - device is offline",
                     SessionReader.Result.Unknown,
@@ -112,14 +110,16 @@ class RemoteSessionReaderTest {
                     named(
                         "true with expected log entry when API response is Success with correct " +
                             "response format - with redirectUri (mobile journey)",
-                        ApiResponse.Success<String>(
-                            """
-                            {
-                                "sessionId": "test session ID",
-                                "redirectUri": "https://example/redirect",
-                                "state": "11112222333344445555666677778888"
-                            }
-                            """.trimIndent(),
+                        ApiResponse.Success(
+                            response =
+                                """
+                                {
+                                    "sessionId": "test session ID",
+                                    "redirectUri": "https://example/redirect",
+                                    "state": "11112222333344445555666677778888"
+                                }
+                                """.trimIndent(),
+                            status = 200,
                         ),
                     ),
                     "Got active session",
@@ -134,15 +134,17 @@ class RemoteSessionReaderTest {
                     named(
                         "true with expected log entry when API response is Success with correct " +
                             "response format - with new parameters",
-                        ApiResponse.Success<String>(
-                            """
-                            {
-                                "sessionId": "test session ID",
-                                "redirectUri": "https://example/redirect",
-                                "additionalParameter": true,
-                                "state": "11112222333344445555666677778888"
-                            }
-                            """.trimIndent(),
+                        ApiResponse.Success(
+                            response =
+                                """
+                                {
+                                    "sessionId": "test session ID",
+                                    "redirectUri": "https://example/redirect",
+                                    "additionalParameter": true,
+                                    "state": "11112222333344445555666677778888"
+                                }
+                                """.trimIndent(),
+                            status = 200,
                         ),
                     ),
                     "Got active session",
@@ -157,14 +159,16 @@ class RemoteSessionReaderTest {
                     named(
                         "true with expected log entry when API response is Success with correct " +
                             "response format - with existing query parameters on the redirect URI",
-                        ApiResponse.Success<String>(
-                            """
-                            {
-                                "sessionId": "test session ID",
-                                "redirectUri": "https://example/redirect?test=test",
-                                "state": "11112222333344445555666677778888"
-                            }
-                            """.trimIndent(),
+                        ApiResponse.Success(
+                            response =
+                                """
+                                {
+                                    "sessionId": "test session ID",
+                                    "redirectUri": "https://example/redirect?test=test",
+                                    "state": "11112222333344445555666677778888"
+                                }
+                                """.trimIndent(),
+                            status = 200,
                         ),
                     ),
                     "Got active session",
@@ -179,14 +183,16 @@ class RemoteSessionReaderTest {
                     named(
                         "true with expected log entry when API response is Success with correct " +
                             "response format - with state that requires URI encoding",
-                        ApiResponse.Success<String>(
-                            """
-                            {
-                                "sessionId": "test session ID",
-                                "redirectUri": "https://example/redirect",
-                                "state": "&?%:/"
-                            }
-                            """.trimIndent(),
+                        ApiResponse.Success(
+                            response =
+                                """
+                                {
+                                    "sessionId": "test session ID",
+                                    "redirectUri": "https://example/redirect",
+                                    "state": "&?%:/"
+                                }
+                                """.trimIndent(),
+                            status = 200,
                         ),
                     ),
                     "Got active session",
@@ -201,13 +207,15 @@ class RemoteSessionReaderTest {
                     named(
                         "true with expected log entry when API response is Success with correct " +
                             "response format - no redirectUri (desktop journey)",
-                        ApiResponse.Success<String>(
-                            """
-                            {
-                                "sessionId": "test session ID",
-                                "state": "11112222333344445555666677778888"
-                            }
-                            """.trimIndent(),
+                        ApiResponse.Success(
+                            response =
+                                """
+                                {
+                                    "sessionId": "test session ID",
+                                    "state": "11112222333344445555666677778888"
+                                }
+                                """.trimIndent(),
+                            status = 200,
                         ),
                     ),
                     "Got active session",
@@ -222,14 +230,16 @@ class RemoteSessionReaderTest {
                     named(
                         "false with expected log entry when API response is Success but with " +
                             "incorrect response format",
-                        ApiResponse.Success<String>(
-                            """
-                            {
-                                "sessionId_WRONG": "test session ID",
-                                "redirectUri": "https://example/redirect",
-                                "state": "11112222333344445555666677778888"
-                            }
-                            """.trimIndent(),
+                        ApiResponse.Success(
+                            response =
+                                """
+                                {
+                                    "sessionId_WRONG": "test session ID",
+                                    "redirectUri": "https://example/redirect",
+                                    "state": "11112222333344445555666677778888"
+                                }
+                                """.trimIndent(),
+                            status = 200,
                         ),
                     ),
                     "Failed to parse active session response",

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/FakeAbortSessionApiTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/FakeAbortSessionApiTest.kt
@@ -5,8 +5,10 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.TransportException
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.FakeConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
@@ -37,7 +39,7 @@ class FakeAbortSessionApiTest {
                     ),
             )
             val result = fakeApi.abortSession("sessionId")
-            assertEquals(ApiResponse.Success(""), result)
+            assertEquals(ApiResponse.Success(response = "", status = 200), result)
         }
 
     @Test
@@ -54,7 +56,8 @@ class FakeAbortSessionApiTest {
                     ),
             )
             val result = fakeApi.abortSession("sessionId")
-            assertEquals(ApiResponse.Offline, result)
+            assertTrue(result is ApiResponse.Failure)
+            assertTrue((result as ApiResponse.Failure).error is TransportException)
         }
 
     @Test

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/RealAbortSessionApiTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/RealAbortSessionApiTest.kt
@@ -32,7 +32,7 @@ class RealAbortSessionApiTest {
         )
         api =
             RealAbortSessionApi(
-                httpClient = createTestHttpClient(),
+                networkService = createTestHttpClient(),
                 configStore = fakeConfigStore,
             )
     }

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/RealAbortSessionApiTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/abort/RealAbortSessionApiTest.kt
@@ -2,15 +2,15 @@ package uk.gov.onelogin.criorchestrator.features.session.internal.network.abort
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.FakeConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
 import uk.gov.onelogin.criorchestrator.libraries.testing.networking.Imposter
 import uk.gov.onelogin.criorchestrator.libraries.testing.networking.createTestHttpClient
+import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RealAbortSessionApiTest {
@@ -40,9 +40,8 @@ class RealAbortSessionApiTest {
     @Test
     fun `it responds`() =
         runTest {
-            val expected = ApiResponse.Success<String>("example")
-
             val result = api.abortSession("sessionId")
-            assertEquals(expected, result)
+            val success = result as ApiResponse.Success
+            assertEquals("example", success.response)
         }
 }

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiImplTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiImplTest.kt
@@ -32,7 +32,7 @@ class ActiveSessionApiImplTest {
         )
         activeSessionApiImpl =
             ActiveSessionApiImpl(
-                httpClient = createTestHttpClient(),
+                networkService = createTestHttpClient(),
                 configStore = fakeConfigStore,
             )
     }

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiImplTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/ActiveSessionApiImplTest.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.FakeConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
@@ -40,14 +40,13 @@ class ActiveSessionApiImplTest {
     @Test
     fun `session API implementation returns stubbed API response`() =
         runTest {
-            val expected =
-                ApiResponse.Success<String>(
-                    "{\"sessionId\":\"37aae92b-a51e-4f68-b571-8e455fb0ec34\"," +
-                        "\"redirectUri\":\"https://example/redirect\"," +
-                        "\"state\":\"11112222333344445555666677778888\"}",
-                )
-
             val result = activeSessionApiImpl.getActiveSession()
-            Assertions.assertEquals(expected, result)
+            val success = result as ApiResponse.Success
+            Assertions.assertEquals(
+                "{\"sessionId\":\"37aae92b-a51e-4f68-b571-8e455fb0ec34\"," +
+                    "\"redirectUri\":\"https://example/redirect\"," +
+                    "\"state\":\"11112222333344445555666677778888\"}",
+                success.response,
+            )
         }
 }

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/FakeActiveSessionApiTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/network/activesession/FakeActiveSessionApiTest.kt
@@ -3,7 +3,7 @@ package uk.gov.onelogin.criorchestrator.features.session.internal.network.active
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
 import uk.gov.onelogin.criorchestrator.features.config.internalapi.FakeConfigStore
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
@@ -25,17 +25,17 @@ class FakeActiveSessionApiTest {
                         Config.Value.StringValue(SdkConfigKey.BypassJourneyType.OPTION_MOBILE_APP_MOBILE),
                     ),
             )
+            val result = activeSessionApi.getActiveSession()
+            assertEquals(200, (result as ApiResponse.Success).status)
             assertEquals(
-                ApiResponse.Success<String>(
-                    """
+                """
                     {
                         "sessionId": "test-session-id",
                         "redirectUri": "https://example/redirect",
                         "state": "11112222333344445555666677778888"
                     }
                     """.replace("\\s".toRegex(), ""),
-                ),
-                activeSessionApi.getActiveSession(),
+                result.response,
             )
         }
 
@@ -49,16 +49,16 @@ class FakeActiveSessionApiTest {
                         Config.Value.StringValue(SdkConfigKey.BypassJourneyType.OPTION_DESKTOP_APP_DESKTOP),
                     ),
             )
+            val result = activeSessionApi.getActiveSession()
+            assertEquals(200, (result as ApiResponse.Success).status)
             assertEquals(
-                ApiResponse.Success<String>(
-                    """
+                """
                     {
                         "sessionId": "test-session-id",
                         "state": "11112222333344445555666677778888"
                     }
                     """.replace("\\s".toRegex(), ""),
-                ),
-                activeSessionApi.getActiveSession(),
+                result.response,
             )
         }
 }

--- a/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/usecases/AbortSessionImplTest.kt
+++ b/features/session/internal/src/test/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/usecases/AbortSessionImplTest.kt
@@ -5,10 +5,12 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
-import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.given
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.ApiResponseException
+import uk.gov.android.network.service.NetworkingException
+import uk.gov.android.network.service.TransportException
 import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.criorchestrator.features.session.internal.network.abort.AbortSessionApi
 import uk.gov.onelogin.criorchestrator.features.session.internalapi.domain.AbortSession
@@ -57,7 +59,7 @@ class AbortSessionImplTest {
     @Test
     fun `given api response is success, it updates the session to aborted`() =
         runTest {
-            givenResponse(ApiResponse.Success(""))
+            givenResponse(ApiResponse.Success(response = "", status = 200))
             assertNotNull(sessionStore.read().first())
 
             abortSession()
@@ -71,7 +73,7 @@ class AbortSessionImplTest {
     @Test
     fun `given api response is success, it returns success`() =
         runTest {
-            givenResponse(ApiResponse.Success(""))
+            givenResponse(ApiResponse.Success(response = "", status = 200))
 
             val result = abortSession()
 
@@ -81,7 +83,12 @@ class AbortSessionImplTest {
     @Test
     fun `given api response is unrecoverable error, it doesn't clear the session store`() =
         runTest {
-            givenResponse(ApiResponse.Failure(401, error = Exception("error")))
+            givenResponse(
+                ApiResponse.Failure(
+                    error = ApiResponseException("error", null),
+                    status = 401,
+                ),
+            )
             assertNotNull(sessionStore.read().first())
 
             abortSession()
@@ -92,8 +99,8 @@ class AbortSessionImplTest {
     @Test
     fun `given api response is unrecoverable error, it returns error`() =
         runTest {
-            val exception = Exception("error")
-            givenResponse(ApiResponse.Failure(401, error = exception))
+            val exception = ApiResponseException("error", null)
+            givenResponse(ApiResponse.Failure(error = exception, status = 401))
 
             val result = abortSession()
 
@@ -103,7 +110,7 @@ class AbortSessionImplTest {
     @Test
     fun `given api response is offline, it doesn't clear the session store`() =
         runTest {
-            givenResponse(ApiResponse.Offline)
+            givenResponse(ApiResponse.Failure(error = TransportException(cause = null)))
             assertNotNull(sessionStore.read().first())
 
             abortSession()
@@ -114,23 +121,13 @@ class AbortSessionImplTest {
     @Test
     fun `given api response is offline, it returns error`() =
         runTest {
-            givenResponse(ApiResponse.Offline)
+            givenResponse(ApiResponse.Failure(error = TransportException(cause = null)))
 
             val result = abortSession()
 
             assertEquals(AbortSession.Result.Error.Offline, result)
         }
 
-    @Test
-    fun `given api response is loading, it throws`() =
-        runTest {
-            givenResponse(ApiResponse.Loading)
-
-            assertThrows<IllegalStateException> {
-                abortSession()
-            }
-        }
-
-    private suspend fun givenResponse(apiResponse: ApiResponse) =
+    private suspend fun givenResponse(apiResponse: ApiResponse<String, NetworkingException>) =
         given(abortSessionApi.abortSession(sessionId)).willReturn(apiResponse)
 }

--- a/features/session/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/StubActiveSessionApiImpl.kt
+++ b/features/session/internal/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/features/session/internal/StubActiveSessionApiImpl.kt
@@ -1,14 +1,17 @@
 package uk.gov.onelogin.criorchestrator.features.session.internal
 
-import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.NetworkingException
+import uk.gov.android.network.service.TransportException
 import uk.gov.onelogin.criorchestrator.features.session.internal.network.activesession.ActiveSessionApi
 
 class StubActiveSessionApiImpl : ActiveSessionApi {
-    private var returnedResponse: ApiResponse = ApiResponse.Offline
+    private var returnedResponse: ApiResponse<String, NetworkingException> =
+        ApiResponse.Failure(error = TransportException(cause = null))
 
-    fun setActiveSession(response: ApiResponse) {
+    fun setActiveSession(response: ApiResponse<String, NetworkingException>) {
         returnedResponse = response
     }
 
-    override suspend fun getActiveSession(): ApiResponse = returnedResponse
+    override suspend fun getActiveSession(): ApiResponse<String, NetworkingException> = returnedResponse
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,8 @@ kotlinx-serialization-json = "1.11.0"
 ksp = "2.3.7"
 lifecycle = "2.10.0"
 metro = "1.1.1"
-mockito = "6.3.0"
+mockito-android = "5.23.0"
+mockito-kotlin = "6.3.0"
 molecule = "2.2.0"
 navigation = "2.9.7"
 paparazzi = "2.0.0-alpha05"
@@ -34,7 +35,8 @@ turbine = "1.2.1"
 uk-gov-logging = "0.40.12" # https://github.com/orgs/govuk-one-login/packages?repo_name=mobile-android-logging
 uk-gov-networking = "0.14.0"
 uk-gov-ui = "17.1.1"
-gov-uk-idcheck = "0.43.0" # https://github.com/govuk-one-login/mobile-id-check-android-sdk/releases
+gov-uk-idcheck = "0.44.0" # https://github.com/govuk-one-login/mobile-id-check-android-sdk/releases
+
 
 [libraries]
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
@@ -91,7 +93,8 @@ org-junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter" }
 org-junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine" }
 org-junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
 org-junit-vintage = { group = "org.junit.vintage", name = "junit-vintage-engine" }
-org-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito" }
+org-mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockito-android" }
+org-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito-kotlin" }
 org-robolectric-robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 uk-gov-logging-api = { group = "uk.gov.logging", name = "logging-api", version.ref = "uk-gov-logging" }
 uk-gov-logging-impl = { group = "uk.gov.logging", name = "logging-impl", version.ref = "uk-gov-logging" }

--- a/libraries/testing/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/libraries/testing/networking/CreateTestHttpClient.kt
+++ b/libraries/testing/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/libraries/testing/networking/CreateTestHttpClient.kt
@@ -2,13 +2,16 @@ package uk.gov.onelogin.criorchestrator.libraries.testing.networking
 
 import uk.gov.android.network.auth.AuthenticationProvider
 import uk.gov.android.network.auth.AuthenticationResponse
-import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.android.network.client.KtorHttpClient
+import uk.gov.android.network.service.DefaultNetworkService
+import uk.gov.android.network.service.NetworkService
 import uk.gov.android.network.useragent.UserAgentGeneratorStub
 
-fun createTestHttpClient(): GenericHttpClient =
-    KtorHttpClient(
-        userAgentGenerator = UserAgentGeneratorStub("userAgent"),
+fun createTestHttpClient(): NetworkService =
+    DefaultNetworkService(
+        KtorHttpClient(
+            userAgentGenerator = UserAgentGeneratorStub("userAgent"),
+        ),
     ).apply {
         setAuthenticationProvider(StubAuthenticationProvider())
     }

--- a/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/BaseCriOrchestratorAppGraph.kt
+++ b/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/BaseCriOrchestratorAppGraph.kt
@@ -6,7 +6,7 @@ import dev.zacsweers.metro.Named
 import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.android.network.service.NetworkService
 import uk.gov.logging.api.Logger
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
@@ -24,7 +24,7 @@ interface BaseCriOrchestratorAppGraph {
     fun interface Factory {
         @Suppress("LongParameterList")
         fun create(
-            @Provides authenticatedHttpClient: GenericHttpClient,
+            @Provides authenticatedHttpClient: NetworkService,
             @Provides analyticsLogger: AnalyticsLogger,
             @Provides initialConfig: Config,
             @Provides logger: Logger,
@@ -43,5 +43,5 @@ interface BaseCriOrchestratorAppGraph {
 
     fun analyticsLogger(): AnalyticsLogger
 
-    fun authenticatedHttpClient(): GenericHttpClient
+    fun authenticatedHttpClient(): NetworkService
 }

--- a/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/CriOrchestratorSingletonImpl.kt
+++ b/sdk/internal/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/internal/CriOrchestratorSingletonImpl.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import dev.zacsweers.metro.createGraphFactory
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
-import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.android.network.service.NetworkService
 import uk.gov.logging.api.Logger
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
@@ -23,7 +23,7 @@ import uk.gov.onelogin.criorchestrator.sdk.sharedapi.CriOrchestratorSdk
  *   IO, Default and Unconfined dispatchers.
  */
 class CriOrchestratorSingletonImpl(
-    authenticatedHttpClient: GenericHttpClient,
+    authenticatedHttpClient: NetworkService,
     analyticsLogger: AnalyticsLogger,
     userConfig: Config,
     logger: Logger,

--- a/sdk/public-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/publicapi/CriOrchestratorSdkExt.kt
+++ b/sdk/public-api/src/main/kotlin/uk/gov/onelogin/criorchestrator/sdk/publicapi/CriOrchestratorSdkExt.kt
@@ -1,7 +1,7 @@
 package uk.gov.onelogin.criorchestrator.sdk.publicapi
 
 import android.content.Context
-import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.android.network.service.NetworkService
 import uk.gov.logging.api.Logger
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
@@ -18,7 +18,7 @@ object CriOrchestratorSdkExt {
      * Take care to ensure that only one instance of this object is created.
      */
     fun CriOrchestratorSdk.Companion.create(
-        authenticatedHttpClient: GenericHttpClient,
+        authenticatedHttpClient: NetworkService,
         analyticsLogger: AnalyticsLogger,
         initialConfig: Config,
         logger: Logger,

--- a/sdk/public-api/src/test/kotlin/uk/gov/onelogin/criorchestrator/sdk/publicapi/RememberCriOrchestratorKtTest.kt
+++ b/sdk/public-api/src/test/kotlin/uk/gov/onelogin/criorchestrator/sdk/publicapi/RememberCriOrchestratorKtTest.kt
@@ -14,8 +14,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertInstanceOf
 import org.mockito.kotlin.mock
-import uk.gov.android.network.api.ApiResponse
-import uk.gov.android.network.client.StubHttpClient
+import uk.gov.android.network.service.NetworkService
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
@@ -38,7 +37,7 @@ class RememberCriOrchestratorKtTest {
         )
     private val criOrchestratorSdk =
         CriOrchestratorSdk.create(
-            authenticatedHttpClient = StubHttpClient(apiResponse = ApiResponse.Offline),
+            authenticatedHttpClient = mock<NetworkService>(),
             analyticsLogger = mock<AnalyticsLogger>(),
             initialConfig = initialConfig,
             logger = SystemLogger(),

--- a/sdk/public-api/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/sdk/publicapi/CriOrchestratorSdkTestExt.kt
+++ b/sdk/public-api/src/testFixtures/kotlin/uk/gov/onelogin/criorchestrator/sdk/publicapi/CriOrchestratorSdkTestExt.kt
@@ -5,9 +5,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.mockito.Mockito.mock
-import uk.gov.android.network.api.ApiResponse
-import uk.gov.android.network.client.GenericHttpClient
-import uk.gov.android.network.client.StubHttpClient
+import uk.gov.android.network.service.NetworkService
 import uk.gov.logging.api.Logger
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
@@ -17,10 +15,7 @@ import uk.gov.onelogin.criorchestrator.sdk.sharedapi.CriOrchestratorSdk
 @OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("LongParameterList")
 fun CriOrchestratorSdk.Companion.createTestInstance(
-    authenticatedHttpClient: GenericHttpClient =
-        StubHttpClient(
-            apiResponse = ApiResponse.Offline,
-        ),
+    authenticatedHttpClient: NetworkService = mock(),
     analyticsLogger: AnalyticsLogger = mock(),
     initialConfig: Config = Config.createTestInstance(),
     logger: Logger = mock(),

--- a/test-wrapper/build.gradle.kts
+++ b/test-wrapper/build.gradle.kts
@@ -42,5 +42,6 @@ dependencies {
     testFixturesImplementation(libs.androidx.ui.test.junit4)
 
     androidTestImplementation(libs.androidx.test.rules)
+    androidTestImplementation(libs.org.mockito.android)
     androidTestImplementation(testFixtures(projects.sdk.publicApi))
 }

--- a/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/hilt/CriOrchestratorSdkHiltModule.kt
+++ b/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/hilt/CriOrchestratorSdkHiltModule.kt
@@ -6,7 +6,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.android.network.service.NetworkService
 import uk.gov.logging.api.Logger
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.onelogin.criorchestrator.sdk.publicapi.CriOrchestratorSdkExt.create
@@ -23,11 +23,11 @@ object CriOrchestratorSdkHiltModule {
         analyticsLogger: AnalyticsLogger,
         application: Application,
         logger: Logger,
-        httpClient: GenericHttpClient,
+        networkService: NetworkService,
         resources: Resources,
     ): CriOrchestratorSdk =
         CriOrchestratorSdk.create(
-            authenticatedHttpClient = httpClient,
+            authenticatedHttpClient = networkService,
             analyticsLogger = analyticsLogger,
             initialConfig = TestWrapperConfig.provideConfig(resources),
             logger = logger,

--- a/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/hilt/HttpClientHiltModule.kt
+++ b/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/hilt/HttpClientHiltModule.kt
@@ -5,7 +5,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.android.network.service.NetworkService
 import uk.gov.onelogin.criorchestrator.testwrapper.SubjectTokenRepository
 import uk.gov.onelogin.criorchestrator.testwrapper.network.createHttpClient
 import javax.inject.Singleton
@@ -15,10 +15,10 @@ import javax.inject.Singleton
 object HttpClientHiltModule {
     @Provides
     @Singleton
-    fun providesGenericHttpClient(
+    fun providesNetworkService(
         resources: Resources,
         subjectTokenRepository: SubjectTokenRepository,
-    ): GenericHttpClient =
+    ): NetworkService =
         createHttpClient(
             subjectTokenRepository = subjectTokenRepository,
             resources = resources,

--- a/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/network/HttpClient.kt
+++ b/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/network/HttpClient.kt
@@ -2,23 +2,26 @@ package uk.gov.onelogin.criorchestrator.testwrapper.network
 
 import android.content.res.Resources
 import kotlinx.serialization.json.Json
-import uk.gov.android.network.api.ApiRequest
-import uk.gov.android.network.api.ApiResponse.Success
+import uk.gov.android.network.api.v2.ApiRequest
 import uk.gov.android.network.auth.AuthenticationProvider
 import uk.gov.android.network.auth.AuthenticationResponse
-import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.android.network.client.KtorHttpClient
+import uk.gov.android.network.service.DefaultNetworkService
+import uk.gov.android.network.service.NetworkService
 import uk.gov.android.network.useragent.UserAgentGeneratorStub
 import uk.gov.onelogin.criorchestrator.testwrapper.R
 import uk.gov.onelogin.criorchestrator.testwrapper.SubjectTokenRepository
 import javax.inject.Provider
+import uk.gov.android.network.api.v2.ApiResponse as ApiResponseV2
 
 internal fun createHttpClient(
     subjectTokenRepository: SubjectTokenRepository,
     resources: Resources,
-): GenericHttpClient =
-    KtorHttpClient(
-        userAgentGenerator = UserAgentGeneratorStub("userAgent"),
+): NetworkService =
+    DefaultNetworkService(
+        KtorHttpClient(
+            userAgentGenerator = UserAgentGeneratorStub("userAgent"),
+        ),
     ).apply {
         setAuthenticationProvider(
             TestWrapperAuthenticationProvider(
@@ -33,9 +36,11 @@ internal fun createHttpClient(
         )
     }
 
-internal fun createStubHttpClient(): GenericHttpClient =
-    KtorHttpClient(
-        userAgentGenerator = UserAgentGeneratorStub("userAgent"),
+internal fun createStubHttpClient(): NetworkService =
+    DefaultNetworkService(
+        KtorHttpClient(
+            userAgentGenerator = UserAgentGeneratorStub("userAgent"),
+        ),
     ).apply {
         setAuthenticationProvider(
             StubAuthenticationProvider(),
@@ -58,7 +63,7 @@ internal class TestWrapperAuthenticationProvider(
 }
 
 internal class MockStsAuthenticationProvider(
-    val client: Provider<GenericHttpClient>,
+    val client: Provider<NetworkService>,
     val resources: Resources,
 ) {
     suspend fun fetchBearerToken(
@@ -80,11 +85,11 @@ internal class MockStsAuthenticationProvider(
             )
 
         val response = client.get().makeRequest(request)
-        if (response !is Success<*>) {
+        if (response !is ApiResponseV2.Success) {
             return AuthenticationResponse.Failure(Exception("Could not exchange token with STS mock"))
         }
 
-        val tokenResponse = jsonFormat.decodeFromString<TokenResponse>(response.response.toString())
+        val tokenResponse = jsonFormat.decodeFromString<TokenResponse>(response.response)
         return AuthenticationResponse.Success(tokenResponse.accessToken)
     }
 

--- a/test-wrapper/src/test/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/integration/DeveloperSettingsTest.kt
+++ b/test-wrapper/src/test/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/integration/DeveloperSettingsTest.kt
@@ -16,9 +16,16 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import uk.gov.android.network.api.v2.ApiResponse
+import uk.gov.android.network.service.NetworkService
+import uk.gov.android.network.service.TransportException
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.Config
 import uk.gov.onelogin.criorchestrator.features.config.publicapi.SdkConfigKey
@@ -44,9 +51,19 @@ class DeveloperSettingsTest {
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
+    private val mockNetworkService =
+        mock<NetworkService>().also {
+            runBlocking {
+                whenever(it.makeRequest(any(), any())).thenReturn(
+                    ApiResponse.Failure(error = TransportException(cause = null)),
+                )
+            }
+        }
+
     val criOrchestratorSdk =
         CriOrchestratorSdk.createTestInstance(
             applicationContext = context,
+            authenticatedHttpClient = mockNetworkService,
             initialConfig =
                 Config.createTestInstance(
                     isNfcAvailable = false,

--- a/test-wrapper/src/test/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/network/MockStsAuthenticationProviderTest.kt
+++ b/test-wrapper/src/test/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/network/MockStsAuthenticationProviderTest.kt
@@ -7,17 +7,18 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
-import uk.gov.android.network.api.ApiRequest
-import uk.gov.android.network.api.ApiResponse
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import uk.gov.android.network.api.v2.ApiRequest
 import uk.gov.android.network.auth.AuthenticationResponse
-import uk.gov.android.network.client.GenericHttpClient
-import uk.gov.android.network.client.StubHttpClient
+import uk.gov.android.network.service.NetworkService
 import uk.gov.onelogin.criorchestrator.testwrapper.R
 import uk.gov.onelogin.criorchestrator.testwrapper.network.MockStsAuthenticationProvider.Companion.GRANT_TYPE
 import uk.gov.onelogin.criorchestrator.testwrapper.network.MockStsAuthenticationProvider.Companion.SUBJECT_TOKEN_TYPE
 import javax.inject.Provider
 import kotlin.test.assertEquals
 import kotlin.test.fail
+import uk.gov.android.network.api.v2.ApiResponse as ApiResponseV2
 
 class MockStsAuthenticationProviderTest {
     private val resources = mock<Resources>()
@@ -32,7 +33,7 @@ class MockStsAuthenticationProviderTest {
 
     @Test
     fun `it should make a request to exchange the subject token`() {
-        val mockClient = mock<GenericHttpClient>()
+        val mockClient = mock<NetworkService>()
 
         val provider =
             MockStsAuthenticationProvider(
@@ -61,26 +62,28 @@ class MockStsAuthenticationProviderTest {
     @Test
     fun `it should correctly return a well-formed authentication response`() {
         val accessToken = "example_access_token"
-
-        val provider =
-            MockStsAuthenticationProvider(
-                client =
-                    Provider {
-                        StubHttpClient(
-                            ApiResponse.Success(
-                                """
-                                {
-                                  "access_token": "$accessToken",
-                                  "expires_in": 10
-                                }
-                                """.trimIndent(),
-                            ),
-                        )
-                    },
-                resources = resources,
-            )
+        val mockClient = mock<NetworkService>()
 
         runTest {
+            whenever(mockClient.makeRequest(any(), any())).thenReturn(
+                ApiResponseV2.Success(
+                    response =
+                        """
+                        {
+                          "access_token": "$accessToken",
+                          "expires_in": 10
+                        }
+                        """.trimIndent(),
+                    status = 200,
+                ),
+            )
+
+            val provider =
+                MockStsAuthenticationProvider(
+                    client = Provider { mockClient },
+                    resources = resources,
+                )
+
             when (val response = provider.fetchBearerToken(scope, subjectToken)) {
                 is AuthenticationResponse.Failure ->
                     fail("expected a success response")
@@ -94,27 +97,29 @@ class MockStsAuthenticationProviderTest {
     @Test
     fun `it should ignore additional json attributes`() {
         val accessToken = "example_access_token"
-
-        val provider =
-            MockStsAuthenticationProvider(
-                client =
-                    Provider {
-                        StubHttpClient(
-                            ApiResponse.Success(
-                                """
-                                {
-                                  "access_token": "$accessToken",
-                                  "expires_in": 10,
-                                  "token_type": "bearer"
-                                }
-                                """.trimIndent(),
-                            ),
-                        )
-                    },
-                resources = resources,
-            )
+        val mockClient = mock<NetworkService>()
 
         runTest {
+            whenever(mockClient.makeRequest(any(), any())).thenReturn(
+                ApiResponseV2.Success(
+                    response =
+                        """
+                        {
+                          "access_token": "$accessToken",
+                          "expires_in": 10,
+                          "token_type": "bearer"
+                        }
+                        """.trimIndent(),
+                    status = 200,
+                ),
+            )
+
+            val provider =
+                MockStsAuthenticationProvider(
+                    client = Provider { mockClient },
+                    resources = resources,
+                )
+
             when (val response = provider.fetchBearerToken(scope, subjectToken)) {
                 is AuthenticationResponse.Failure ->
                     fail("expected a success response")


### PR DESCRIPTION
[Tutorial for writing good descriptions]: https://cbea.ms/git-commit/

[//]: # (Be mindful that the PR title also needs to follow conventional commit standards)

# DCMAW-20416: Migrate from GenericHttpClient to NetworkService 

- Bump ID Check SDK version to 0.44.0
- Replace `GenericHttpClient` with `NetworkService` across API implementations
- Use `DefaultNetworkService(KtorHttpClient(...))` to construct `NetworkService` instances
- Switch from v1 to v2 `ApiRequest` with explicit headers instead of `ContentType` enum
- Use `NetworkService.makeRequest()` with configure block for authenticated requests (withAuthentication(scope))
- Remove v1 `ApiResponse` (including `Offline` and `Loading` variants) in favour of v2 `ApiResponse<String, NetworkingException>`
- Detect `offline`/`network` failures via `TransportException` in `ApiResponse.Failure` to maintain existing offline journeys

Detailed released notes for Networking library v0.14.0 can be found [here](https://github.com/govuk-one-login/mobile-android-networking/releases/tag/v0.14.0)

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change
See ID Check SDK [PR](https://github.com/govuk-one-login/mobile-id-check-android-sdk/pull/565)

[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [x] Check against acceptance criteria
- [x] Add automated tests
- [x] Self-review code
