### PR TITLE
feat: DCMAW-21801 Add opt out to predictive back animations

### DIFF
--- a/test-wrapper/src/main/AndroidManifest.xml
+++ b/test-wrapper/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.CRIOrchestratorTemplate"
+        android:enableOnBackInvokedCallback="false"
         tools:replace="android:fullBackupContent, android:dataExtractionRules, android:theme"
         tools:targetApi="35">
         <activity


### PR DESCRIPTION
# DCMAW-21801: Temporarily opt-out of predictive back navigation

- Add opt out to test wrapper manifest

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
