### PR TITLE
chore: restore code coverage

### DIFF
--- a/features/dev/internal/build.gradle.kts
+++ b/features/dev/internal/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("uk.gov.onelogin.criorchestrator.ui-config")
 }
 
-// apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
+apply(from = rootProject.file("gradle/snapshot-test-filter.gradle.kts"))
 
 dependencies {
     api(libs.androidx.lifecycle.viewmodel.compose)

--- a/features/dev/internal/build.gradle.kts
+++ b/features/dev/internal/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("uk.gov.onelogin.criorchestrator.ui-config")
 }
 
-apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
+// apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
 
 dependencies {
     api(libs.androidx.lifecycle.viewmodel.compose)

--- a/features/error/internal/build.gradle.kts
+++ b/features/error/internal/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("uk.gov.onelogin.criorchestrator.analytics-report")
 }
 
-apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
+// apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
 
 dependencies {
     api(libs.androidx.lifecycle.viewmodel.compose)

--- a/features/error/internal/build.gradle.kts
+++ b/features/error/internal/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("uk.gov.onelogin.criorchestrator.analytics-report")
 }
 
-// apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
+apply(from = rootProject.file("gradle/snapshot-test-filter.gradle.kts"))
 
 dependencies {
     api(libs.androidx.lifecycle.viewmodel.compose)

--- a/features/handback/internal/build.gradle.kts
+++ b/features/handback/internal/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
+// apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
 
 dependencies {
     api(libs.androidx.lifecycle.viewmodel.compose)

--- a/features/handback/internal/build.gradle.kts
+++ b/features/handback/internal/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-// apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
+apply(from = rootProject.file("gradle/snapshot-test-filter.gradle.kts"))
 
 dependencies {
     api(libs.androidx.lifecycle.viewmodel.compose)

--- a/features/id-check-wrapper/internal/build.gradle.kts
+++ b/features/id-check-wrapper/internal/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-// apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
+apply(from = rootProject.file("gradle/snapshot-test-filter.gradle.kts"))
 
 dependencies {
     implementation(libs.androidx.navigation.compose)

--- a/features/id-check-wrapper/internal/build.gradle.kts
+++ b/features/id-check-wrapper/internal/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
+// apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
 
 dependencies {
     implementation(libs.androidx.navigation.compose)

--- a/features/resume/internal/build.gradle.kts
+++ b/features/resume/internal/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("uk.gov.onelogin.criorchestrator.analytics-report")
 }
 
-apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
+// apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
 
 dependencies {
     api(libs.androidx.lifecycle.viewmodel.compose)

--- a/features/resume/internal/build.gradle.kts
+++ b/features/resume/internal/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("uk.gov.onelogin.criorchestrator.analytics-report")
 }
 
-// apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
+apply(from = rootProject.file("gradle/snapshot-test-filter.gradle.kts"))
 
 dependencies {
     api(libs.androidx.lifecycle.viewmodel.compose)

--- a/features/select-doc/internal/build.gradle.kts
+++ b/features/select-doc/internal/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
+// apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
 
 dependencies {
     api(libs.androidx.lifecycle.viewmodel.compose)

--- a/features/select-doc/internal/build.gradle.kts
+++ b/features/select-doc/internal/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-// apply(from = rootProject.file("mobile-android-pipelines/buildLogic/gradle/snapshot-test-filter.gradle.kts"))
+apply(from = rootProject.file("gradle/snapshot-test-filter.gradle.kts"))
 
 dependencies {
     api(libs.androidx.lifecycle.viewmodel.compose)

--- a/gradle/snapshot-test-filter.gradle.kts
+++ b/gradle/snapshot-test-filter.gradle.kts
@@ -8,13 +8,15 @@ gradle.taskGraph.whenReady {
             it.contains("paparazzi", ignoreCase = true)
         }
         logger.lifecycle("🔍 Snapshot task detected: $isSnapshotTask")
-        doFirst {
-            if (isSnapshotTask) {
-                logger.lifecycle("📸 Running snapshot tests only in task: $name")
-                include("**/*ScreenshotTest.class")
-            } else {
-                logger.lifecycle("🚫 Excluding snapshot tests in task: $name")
-                exclude("**/*ScreenshotTest.class")
+        if (isSnapshotTask) {
+            logger.lifecycle("📸 Running snapshot tests only in task: $name")
+            filter {
+                includeTestsMatching("**/*ScreenshotTest.class")
+            }
+        } else {
+            logger.lifecycle("🚫 Excluding snapshot tests in task: $name")
+            filter {
+                excludeTestsMatching("**/*ScreenshotTest.class")
             }
         }
     }

--- a/gradle/snapshot-test-filter.gradle.kts
+++ b/gradle/snapshot-test-filter.gradle.kts
@@ -3,11 +3,11 @@
 // this filter to modules with only screenshot tests (e.g. ui-component) will result in no tests
 // being discovered during unit test runs.
 gradle.taskGraph.whenReady {
-    val snapshotKeywords = listOf("recordPaparazzi", "verifyPaparazzi")
-    val isSnapshotTask = allTasks.any { task -> snapshotKeywords.any(task.name::contains) }
-    logger.lifecycle("🔍 Snapshot task detected: $isSnapshotTask")
-
-    project.tasks.withType(Test::class.java).configureEach {
+    project.tasks.withType<Test>().configureEach {
+        val isSnapshotTask = gradle.startParameter.taskNames.any {
+            it.contains("paparazzi", ignoreCase = true)
+        }
+        logger.lifecycle("🔍 Snapshot task detected: $isSnapshotTask")
         doFirst {
             if (isSnapshotTask) {
                 logger.lifecycle("📸 Running snapshot tests only in task: $name")

--- a/gradle/snapshot-test-filter.gradle.kts
+++ b/gradle/snapshot-test-filter.gradle.kts
@@ -1,0 +1,21 @@
+// Apply snapshot test filtering logic after task graph is ready.
+// Only apply this to modules that contain both unit tests and screenshot tests (e.g. sdk). Applying
+// this filter to modules with only screenshot tests (e.g. ui-component) will result in no tests
+// being discovered during unit test runs.
+gradle.taskGraph.whenReady {
+    val snapshotKeywords = listOf("recordPaparazzi", "verifyPaparazzi")
+    val isSnapshotTask = allTasks.any { task -> snapshotKeywords.any(task.name::contains) }
+    logger.lifecycle("🔍 Snapshot task detected: $isSnapshotTask")
+
+    project.tasks.withType(Test::class.java).configureEach {
+        doFirst {
+            if (isSnapshotTask) {
+                logger.lifecycle("📸 Running snapshot tests only in task: $name")
+                include("**/*ScreenshotTest.class")
+            } else {
+                logger.lifecycle("🚫 Excluding snapshot tests in task: $name")
+                exclude("**/*ScreenshotTest.class")
+            }
+        }
+    }
+}

--- a/gradle/snapshot-test-filter.gradle.kts
+++ b/gradle/snapshot-test-filter.gradle.kts
@@ -11,12 +11,12 @@ gradle.taskGraph.whenReady {
         if (isSnapshotTask) {
             logger.lifecycle("📸 Running snapshot tests only in task: $name")
             filter {
-                includeTestsMatching("**/*ScreenshotTest.class")
+                include("**/*ScreenshotTest.class")
             }
         } else {
             logger.lifecycle("🚫 Excluding snapshot tests in task: $name")
             filter {
-                excludeTestsMatching("**/*ScreenshotTest.class")
+                exclude("**/*ScreenshotTest.class")
             }
         }
     }

--- a/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/PlaceHolder.kt
+++ b/test-wrapper/src/main/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/PlaceHolder.kt
@@ -1,0 +1,5 @@
+package uk.gov.onelogin.criorchestrator.testwrapper
+
+class PlaceHolder {
+    fun double(value: Int) = value.times(2)
+}

--- a/test-wrapper/src/test/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/PlaceHolderTest.kt
+++ b/test-wrapper/src/test/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/PlaceHolderTest.kt
@@ -1,0 +1,15 @@
+package uk.gov.onelogin.criorchestrator.testwrapper
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Add dummy test so sonar can provide overall test coverage estimation
+ */
+class PlaceHolderTest {
+    @Test
+    fun verifyDouble() {
+        val sut = PlaceHolder()
+        assertEquals(4, sut.double(2))
+    }
+}

--- a/test-wrapper/src/test/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/PlaceHolderTest.kt
+++ b/test-wrapper/src/test/kotlin/uk/gov/onelogin/criorchestrator/testwrapper/PlaceHolderTest.kt
@@ -1,6 +1,6 @@
 package uk.gov.onelogin.criorchestrator.testwrapper
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**


### PR DESCRIPTION
# DCMAW-20036: Apply snapshot actions in CRI Orchestrator modules

- Remove test filter plugins from modules
- Add dummy class and test to force Sonar to estimate overall test coverage

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change


[//]: # (Screenshots / uploaded videos go here)

## Checklist

- [ ] Check against acceptance criteria
- [ ] Add automated tests
- [ ] Self-review code
